### PR TITLE
Fix way ylim are passed in vignettes

### DIFF
--- a/R/axes.R
+++ b/R/axes.R
@@ -124,7 +124,7 @@ ylimconform <- function(panels, ylim, data, layout) {
           stop(paste("The y-limit you supplied for panel ", p, " has fewer than 2 points.", sep = ""))
         }
       } else {
-        paneldf <- data[, panels$panels[[p]]]
+        paneldf <- data[, panels$panels[[p]], drop = FALSE]
         if (ncol(paneldf) > 0) {
           ylim_list[[p]] <- defaultscale(paneldf)
         } else {

--- a/R/axes.R
+++ b/R/axes.R
@@ -109,7 +109,7 @@ ylimconform <- function(panels, ylim, data, layout) {
   ylim_list <- list()
   if (is.null(ylim)) {
     for (p in names(panels$panels)) {
-      paneldf <- data[, panels$panels[[p]]]
+      paneldf <- data[, panels$panels[[p]], drop = FALSE]
       if (any(!is.na(paneldf)) && is.finite(max(paneldf)) && is.finite(min(paneldf))) {
         ylim_list[[p]] <- defaultscale(paneldf)
       } else {

--- a/vignettes/plotting-options.Rmd
+++ b/vignettes/plotting-options.Rmd
@@ -307,23 +307,23 @@ In future an RBA colour palette will be added to make it easy to use the RBA-app
 
 `arphit` will automatically guess axes for each panel. However, it is not smart enough to sensibly line up axes across panels (e.g. if you have left and right axes). And stacked bar graphs will confuse it.
 
-Y-limits are controlled by three variables: a minimum, a maximum, and the number of steps to include. These are passed as a vector - e.g. `c(-10,10,5)`. Y-limits can be set for each panel using a list, or can be applied uniformly to all panels.
+Y-limits are controlled by three variables: a minimum, a maximum, and the number of steps to include. These are passed as a list with `min`, `max` and `nsteps` keys - e.g. `list(min = -10,max = 10, nsteps = 5)`. Y-limits can be set for each panel using a list with entries for each panel, or can be applied uniformly to all panels.
 
 ### Example 1: Manually setting left and right axes
 ```
-arphit.tsgraph(data, series = list("1" = c("x1"), "2" = c("x3")), ylim = list("1" = c(-10,10,5), "2" = c(-20,20,5))
+arphit.tsgraph(data, series = list("1" = c("x1"), "2" = c("x3")), ylim = list("1" = list(min = -10, max = 10, nsteps = 5), "2" = list(min = -20, max = 20, nsteps = 5)))
 ```
 ```{r, echo = FALSE, results = "hide"}
-arphit.tsgraph(data, series = list("1" = c("x1"), "2" = c("x3")), ylim = list("1" = c(-10,10,5), "2" = c(-20,20,5)), filename = "y-individual.png")
+arphit.tsgraph(data, series = list("1" = c("x1"), "2" = c("x3")), ylim = list("1" = list(min = -10, max = 10, nsteps = 5), "2" = list(min = -20, max = 20, nsteps = 5)), filename = "y-individual.png")
 ```
 <img src = "y-individual.png", width = "300">
 
 ### Example 2: Applying the same y axis to all panels
 ```
-arphit.tsgraph(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), ylim = c(-10,10,5))
+arphit.tsgraph(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), ylim = list(min = -10, max = 10, nsteps = 5))
 ```
 ```{r, echo = FALSE, results = "hide"}
-arphit.tsgraph(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), ylim = c(-10,10,5), filename = "y-uniform.png")
+arphit.tsgraph(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), ylim = list(min = -10, max = 10, nsteps = 5), filename = "y-uniform.png")
 ```
 <img src = "y-uniform.png", width = "300">
 


### PR DESCRIPTION
Was using an incorrect way to pass in. Causing test failures since vignettes couldn't run.