### PR TITLE
Auto build images for readme

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 .travis.yml
 .push_gh_pages.sh
+build-readme-images.R

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -19,13 +19,11 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 mkdir images
-cp ../arphit/inst/doc/simple_example.png images/simple_example.png
-cp ../arphit/inst/doc/complex_example.png images/complex_example.png
-cp ../arphit/inst/doc/nooptions.png images/nooptions.png
-cp ../arphit/inst/doc/lotsofoptions.png images/lotsofoptions.png
-
-ls ../
+cp ../vignettes/simple_example.png images/simple_example.png
+cp ../vignettes/inst/doc/complex_example.png images/complex_example.png
+cp ../vignettes/inst/doc/nooptions.png images/nooptions.png
+cp ../vignettes/inst/doc/lotsofoptions.png images/lotsofoptions.png
 
 git add .
-git commit -m "Auto-deploye vignettes to github pages"
+git commit -m "Auto-deploy vignettes to github pages"
 git push --force --quiet $FULL_REPO master:gh-pages

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -19,7 +19,7 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 
-R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz')"
+R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz' -print -quit)"
 Rscript ../build-readme-images.R
 mkdir images
 cp ../simple_example.png images/simple_example.png

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -18,14 +18,13 @@ git config user.email "travis"
 cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
-mkdir images
-cp ../vignettes/simple_example.png images/simple_example.png
-cp ../vignettes/inst/doc/complex_example.png images/complex_example.png
-cp ../vignettes/inst/doc/nooptions.png images/nooptions.png
-cp ../vignettes/inst/doc/lotsofoptions.png images/lotsofoptions.png
 
-ls ../
-ls ../vignettes
+Rscript ../build-readme-images.R
+mkdir images
+cp ../simple_example.png images/simple_example.png
+cp ../complex_example.png images/complex_example.png
+cp ../nooptions.png images/nooptions.png
+cp ../lotsofoptions.png images/lotsofoptions.png
 
 git add .
 git commit -m "Auto-deploy vignettes to github pages"

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -24,6 +24,8 @@ cp ../arphit/inst/doc/complex_example.png images/complex_example.png
 cp ../arphit/inst/doc/nooptions.png images/nooptions.png
 cp ../arphit/inst/doc/lotsofoptions.png images/lotsofoptions.png
 
+ls ../
+
 git add .
 git commit -m "Auto-deploye vignettes to github pages"
 git push --force --quiet $FULL_REPO master:gh-pages

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -24,6 +24,9 @@ cp ../vignettes/inst/doc/complex_example.png images/complex_example.png
 cp ../vignettes/inst/doc/nooptions.png images/nooptions.png
 cp ../vignettes/inst/doc/lotsofoptions.png images/lotsofoptions.png
 
+ls ../
+ls ../vignettes
+
 git add .
 git commit -m "Auto-deploy vignettes to github pages"
 git push --force --quiet $FULL_REPO master:gh-pages

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -19,7 +19,7 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 
-R CMD INSTALL *.tar.gz
+R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz')"
 Rscript ../build-readme-images.R
 mkdir images
 cp ../simple_example.png images/simple_example.png

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -19,6 +19,9 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 
+find . -type f -iname 'arphit*.tar.gz' -print -quit
+find . -type f -iname '*.tar.gz' -print -quit
+
 R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz' -print -quit)"
 Rscript ../build-readme-images.R
 mkdir images

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -12,7 +12,7 @@ for files in '*.tar.gz'; do
 done
 
 R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz' -print -quit)"
-Rscript ../build-readme-images.R
+Rscript ./build-readme-images.R
 
 cd out
 git init

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -19,6 +19,7 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 
+R CMD INSTALL *.tar.gz
 Rscript ../build-readme-images.R
 mkdir images
 cp ../simple_example.png images/simple_example.png

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -11,6 +11,9 @@ for files in '*.tar.gz'; do
         tar xfz $files
 done
 
+R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz' -print -quit)"
+Rscript ../build-readme-images.R
+
 cd out
 git init
 git config user.name "travis"
@@ -19,11 +22,6 @@ cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
 
-find . -type f -iname 'arphit*.tar.gz' -print -quit
-find . -type f -iname '*.tar.gz' -print -quit
-
-R CMD INSTALL "$(find . -type f -iname 'arphit*.tar.gz' -print -quit)"
-Rscript ../build-readme-images.R
 mkdir images
 cp ../simple_example.png images/simple_example.png
 cp ../complex_example.png images/complex_example.png

--- a/.push_gh_pages.sh
+++ b/.push_gh_pages.sh
@@ -18,7 +18,12 @@ git config user.email "travis"
 cp ../arphit/inst/doc/index.html index.html
 cp ../arphit/inst/doc/plotting-options.html plotting-options.html
 cp ../arphit/inst/doc/todo.html todo.html
+mkdir images
+cp ../arphit/inst/doc/simple_example.png images/simple_example.png
+cp ../arphit/inst/doc/complex_example.png images/complex_example.png
+cp ../arphit/inst/doc/nooptions.png images/nooptions.png
+cp ../arphit/inst/doc/lotsofoptions.png images/lotsofoptions.png
 
 git add .
-git commit -m "Auto-deployed vignettes to github pages"
+git commit -m "Auto-deploye vignettes to github pages"
 git push --force --quiet $FULL_REPO master:gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 after_success:
   - Rscript -e 'covr::coveralls()'
-  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && ./.push_gh_pages.sh
+  - ./.push_gh_pages.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
 
 after_success:
   - Rscript -e 'covr::coveralls()'
-  - ./.push_gh_pages.sh
+  - test $TRAVIS_BRANCH = "master" && test $TRAVIS_PULL_REQUEST = "false" && ./.push_gh_pages.sh

--- a/build-readme-images.R
+++ b/build-readme-images.R
@@ -1,0 +1,35 @@
+# Build all the images used in the readme
+library(arphit)
+
+T <- 48
+data <- ts(data.frame(x1 = rnorm(T), x2 = rnorm(T), x3 = rnorm(T, sd = 10), x4 = rnorm(T, sd = 5), x5 = rnorm(T, sd = 5)), start = c(2000,1), frequency = 12)
+
+
+arphit.tsgraph(data, series = list("1" = "x1"), filename = "simple_example.png")
+
+arphit.tsgraph(data,
+               layout = "2b2",
+               series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3", "x4"), "4" = c("x5")),
+               bars = c("x1"),
+               title = "arphit Makes Graphing Easy",
+               scaleunits = list("1" = "index", "2" = "ppt", "3" = "$", "4" = "000s"),
+               shading = list(list(from = "x3", to = "x4", color= "lightgrey")),
+               labels = list(list(x = 2001, y = 2, text = "A label", panel = 1, color = "red")),
+               lines = list(list(x = 2004, panel = "2")),
+               bgshading = list(list(x1 = NA, y1 = -1, x2 = NA, y2 = 3, panel = "4")),
+               filename = "complex_example.png")
+
+T <- 12
+data <- ts(data.frame(x1 = rnorm(T), x2 = rnorm(T), x3 = rnorm(T, sd = 10), x4 = rnorm(T, sd = 5)), start = c(2000,1), frequency = 4)
+
+arphit.tsgraph(data, filename = "nooptions.png")
+
+arphit.tsgraph(data,
+               series = list("1" = "x1", "2" = "x2", "3" = "x3", "4" = "x4"),
+               layout = "2b2",
+               title = "A Randomly Created Chart",
+               subtitle = "A short example",
+               scaleunits = "index",
+               paneltitles = list("1" = "Series 1", "2" = "Series 2", "3" = "Series 3", "4" = "Series 4"),
+               sources = c("Randomly generated data"),
+               filename = "lotsofoptions.png")


### PR DESCRIPTION
Runs the same script as in the index vignette, but saves them to a folder, to be pushed to gh-pages. This means they can be used in the main README.md by using absolute path links.