### PR TITLE
Easily set all series to be bars

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -8,7 +8,7 @@
 #'   You do not need to supply all panels. For instance, in a one-panel, there is no need to supply series for panel "2" if you want all series on the left hand side axis.
 #'   Alternatively if just a vector of string names is supplied, it will be assumed all series are being plotted in panel 1. Similarly, if series is not supplied at all, all series will be plotted in panel 1.
 #' @param layout (optional) A string indicating the layout of the chart. Valid options are "1" (single panel), "2v" (side-by-side two panel), "2h" (top and bottom two panel), and "2b2" two-by-two four panel chart. Defaults to single panel if not supplied.
-#' @param bars (optional) Vector of string names indicating which series should be bars, rather than lines.
+#' @param bars (optional) Vector of string names indicating which series should be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series will plot as bars.
 #' @param filename (optional) If specified, save image to filename instead of displaying in R. Supports pdf, emf and png extensions.
 #' @param shading (optional) List of shading between series. See the plotting options vignette for information on how to use.
 #' @param title (optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.

--- a/R/panels.R
+++ b/R/panels.R
@@ -40,7 +40,7 @@ handlepanels <- function(series, bars, layout) {
       panels[p] <- series[p]
       for (s in series[[p]]) {
         serieslist[s] <- p
-        if (s %in% bars) {
+        if (s %in% bars || (is.logical(bars) && bars)) {
           barlist[s] <- TRUE
         }
       }

--- a/vignettes/plotting-options.Rmd
+++ b/vignettes/plotting-options.Rmd
@@ -172,6 +172,8 @@ arphit.tsgraph(data, series = list("1" = c("x1","x2"), "2" = c("x3")), bars = c(
 knitr::include_graphics("bars.png")
 ```
 
+Alternatively, if you want all series to be bars, just set `bars = TRUE`. This is equivalent to passing in a vector with all series names.
+
 If you have multiple bar series on one panel, they automatically be stacked. This example plots `x1` and `x2` as
 bars on the left axis.
 ```


### PR DESCRIPTION
Just set `bars = TRUE` rather than having to specify all series by name