### PR TITLE
Use grDevices::windows instead of dev.new

### DIFF
--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -126,7 +126,11 @@ handlelayout <- function(layout) {
 
 startdevice <- function(filename, device, figsize) {
   if (is.null(device)) {
-    grDevices::dev.new(width = figsize$width, height = figsize$height)
+    if (.Platform$OS.type == "windows") {
+      grDevices::windows(width = figsize$width, height = figsize$height)
+    } else {
+      grDevices::dev.new(width = figsize$width, height = figsize$height)
+    }
   } else if (device == "png") {
     grDevices::png(filename = filename, width = figsize$width, height = figsize$height, units = "in", res = PNGDPI)
   } else if (device == "pdf") {


### PR DESCRIPTION
Correctly sizes the plot window (closes #62)

Only on windows operating systems. 