### PR TITLE
Ungroup data before subsetting in gg interface

### DIFF
--- a/R/gg.R
+++ b/R/gg.R
@@ -562,6 +562,8 @@ facetlayout <- function(data, facet, layout) {
 }
 
 addlayertopanel <- function(gg, new, panel) {
+  # Make sure data isn't grouped (causes errors sometimes if it is)
+  new$data <- dplyr::ungroup(new$data)
   # Special case ts data
   if (is.null(new$aes$x) && (stats::is.ts(new$data))) {
     agg_time <-as.Date(lubridate::date_decimal(as.numeric(stats::time(new$data))))

--- a/R/gg.R
+++ b/R/gg.R
@@ -562,8 +562,10 @@ facetlayout <- function(data, facet, layout) {
 }
 
 addlayertopanel <- function(gg, new, panel) {
-  # Make sure data isn't grouped (causes errors sometimes if it is)
-  new$data <- dplyr::ungroup(new$data)
+  if (tibble::is_tibble(new$data) || is.data.frame(new$data)) {
+    # Make sure data isn't grouped (causes errors sometimes if it is)
+    new$data <- dplyr::ungroup(new$data)
+  }
   # Special case ts data
   if (is.null(new$aes$x) && (stats::is.ts(new$data))) {
     agg_time <-as.Date(lubridate::date_decimal(as.numeric(stats::time(new$data))))

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -364,7 +364,7 @@ expect_equal(colnames(bar$data[["1"]]), c("agg_time", "x1", "x2"))
 expect_error(print(bar), NA)
 
 # Failure if data is grouped by a variable not used in the plot (#85)
-foo <- data.frame(x=1:10,y=rnorm(10),unused=letters[1:10]) %>% group_by(unused)
+foo <- dplyr::group_by(data.frame(x=1:10,y=rnorm(10),unused=letters[1:10]), unused)
 bar <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y))
 expect_error(print(bar), NA)
 

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -364,7 +364,7 @@ expect_equal(colnames(bar$data[["1"]]), c("agg_time", "x1", "x2"))
 expect_error(print(bar), NA)
 
 # Failure if data is grouped by a variable not used in the plot (#85)
-foo <- tibble(x=1:10,y=rnorm(10),unused=letters[1:10]) %>% group_by(unused)
+foo <- data.frame(x=1:10,y=rnorm(10),unused=letters[1:10]) %>% group_by(unused)
 bar <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y))
 expect_error(print(bar), NA)
 

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -363,5 +363,10 @@ bar <- arphitgg() + agg_line(agg_aes(y=x1),data=foo) + agg_col(agg_aes(y=x2),dat
 expect_equal(colnames(bar$data[["1"]]), c("agg_time", "x1", "x2"))
 expect_error(print(bar), NA)
 
+# Failure if data is grouped by a variable not used in the plot (#85)
+foo <- tibble(x=1:10,y=rnorm(10),unused=letters[1:10]) %>% group_by(unused)
+bar <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y))
+expect_error(print(bar), NA)
+
 # Shutdown any devices
 graphics.off()


### PR DESCRIPTION
Fixes an error that otherwise occurred because the grouping variable would be kept in the dataset.

Closes #85 