### PR TITLE
Order facets before assigning to panels

### DIFF
--- a/R/gg.R
+++ b/R/gg.R
@@ -640,7 +640,7 @@ addlayer <- function(gg, new, panel) {
   } else {
     layoutoverride <- facetlayout(new$data, new$aes$facet, gg$layout)
     gg$layout <- layoutoverride$layout
-    facets <- unique(new$data[[new$aes$facet]])
+    facets <- sort(unique(new$data[[new$aes$facet]]))
     newseriesnames <- list()
     for (i in 1:length(facets)) {
       panel <- layoutoverride$panels[[i]]

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -363,5 +363,10 @@ bar <- arphitgg() + agg_line(agg_aes(y=x1),data=foo) + agg_col(agg_aes(y=x2),dat
 expect_equal(colnames(bar$data[["1"]]), c("agg_time", "x1", "x2"))
 expect_error(print(bar), NA)
 
+# Order facets
+foo <- data.frame(x=c(1,2,1,2),y=rnorm(4),facet=c("b","b","a","a"), stringsAsFactors = FALSE)
+bar <- arphitgg(foo,agg_aes(x=x,y=y,facet=facet))+agg_col()
+expect_equal(bar$paneltitles, list("1" = "a", "3" = "b"))
+
 # Shutdown any devices
 graphics.off()


### PR DESCRIPTION
Ensures facets get assigned to panels in order. Closes #87 