### PR TITLE
Round in create scale to avoid numerical errors

### DIFF
--- a/R/axes.R
+++ b/R/axes.R
@@ -54,11 +54,10 @@ defaultscale <- function(data,permittedsteps=PERMITTEDSTEPS) {
 }
 
 createscale <- function(minscale,maxscale,nsteps) {
-  scale <- rep(NA,nsteps)
   stepsize <- (maxscale-minscale)/(nsteps-1)
-  for (i in 1:nsteps) {
-    scale[i] <- minscale + (i-1)*stepsize
-  }
+  # Get the significand of the minscale
+  significand <- -floor(log10(abs(minscale)))
+  scale <- round(seq(from=minscale, by=stepsize, length.out=nsteps), significand+4) # Assume the rounding to the level of significance on the minscale + 4 will be _more_ than enough to wipe out small innaccuracies
   return(scale)
 }
 

--- a/tests/testthat/test-axes.R
+++ b/tests/testthat/test-axes.R
@@ -155,3 +155,7 @@ expect_equal(handlexunits(panels2b2, "index"), list("1" = "index", "2" = "index"
 # Axis labels
 expect_equal(handleaxislabels(list("1" = "foo"), onesided), list("1" = "foo"))
 expect_equal(handleaxislabels("foo", onesided), list("1" = "foo", "2" = "foo"))
+
+# Incorrect rounding of labels (#81)
+foo <- createscale(-0.2, 0.4, 4)
+expect_true(foo[2] == 0)


### PR DESCRIPTION
Fixes wacky axis labels resulting from small floating point inaccuracies. Closes #81 