### PR TITLE
Correctly plot bars even if only one observation

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -338,6 +338,7 @@ drawbars <- function(l, series, bars, data, x, attributes, xlim, ylim, bar.stack
   }
   if (length(barcolumns) > 0) {
     bardata <- t(as.matrix(data[, barcolumns]))
+    bardata[is.na(bardata)] <- 0 # singletons don't show otherwise (#82)
     # Split into positive and negative (R doesn't stack well across axes)
     bardata_p <- bardata
     bardata_n <- bardata


### PR DESCRIPTION
Previously had NAs in bardata for missing observations, which (for some reason) meant the barplot didn't print if there was only one non-missing observations. Chnage to replacing NAs with 0s.

Closes #82 