### PR TITLE
Handle when factors are the facet variable

### DIFF
--- a/R/gg.R
+++ b/R/gg.R
@@ -649,10 +649,10 @@ addlayer <- function(gg, new, panel) {
     for (i in 1:length(facets)) {
       panel <- layoutoverride$panels[[i]]
       subset_data <- new
-      subset_data$data <- subset_data$data[new$data[new$aes$facet] == facets[i],]
+      subset_data$data <- subset_data$data[new$data[[new$aes$facet]] == facets[i],]
       out <- addlayertopanel(gg, subset_data, panel)
       gg <- out$gg
-      gg$paneltitles[[panel]] <- facets[i]
+      gg$paneltitles[[panel]] <- as.character(facets[i])
       newseriesnames[[panel]] <- out$newseriesnames
     }
   }

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -368,10 +368,14 @@ foo <- data.frame(x=c(1,2,1,2),y=rnorm(4),facet=c("b","b","a","a"), stringsAsFac
 bar <- arphitgg(foo,agg_aes(x=x,y=y,facet=facet))+agg_col()
 expect_equal(bar$paneltitles, list("1" = "a", "3" = "b"))
 
-# Failure if data is grouped by a variable not used in the plot (#85)
+# Shouldn't fail if data is grouped by a variable not used in the plot (#85)
 foo <- dplyr::group_by(data.frame(x=1:10,y=rnorm(10),unused=letters[1:10]), unused)
 bar <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y))
 expect_error(print(bar), NA)
+
+# Facet variable is a factor (#88)
+foo <- data.frame(x=1:3,b=c("a","b","a"),y=1:3)
+expect_error(arphitgg(foo,agg_aes(x=x,y=y,facet=b)) + agg_line(), NA)
 
 # Shutdown any devices
 graphics.off()


### PR DESCRIPTION
Previously the gg interface had problems handling the case when the facet variable was a factor. Fix that.

Closes #88 by actually handling factors, rather than just providing a helpful error message (as the issue originally suggested).