### PR TITLE
Correctly handle variables with spaces

### DIFF
--- a/R/gg.R
+++ b/R/gg.R
@@ -480,8 +480,15 @@ convert2wide <- function(data, aes) {
   }
 }
 
+addbackticks <- function(x) {
+  paste0("`", x, "`")
+}
+
 subsetdata <- function(data, x, y, group) {
+  x <- addbackticks(x)
+  y <- addbackticks(y)
   if (!is.null(group)) {
+    group <- addbackticks(group)
     return(dplyr::select_(data, x, y, group))
   } else {
     return(dplyr::select_(data, x, y))
@@ -593,7 +600,7 @@ addlayertopanel <- function(gg, new, panel) {
     mergeddata <- dplyr::full_join(gg$data[[panel]], newdata, by = gg$x[[panel]])
     mergeddata <- unrename(mergeddata)
     if (reorder) {
-      mergeddata <- dplyr::arrange_(mergeddata, gg$x[[panel]])
+      mergeddata <- dplyr::arrange_(mergeddata, addbackticks(gg$x[[panel]]))
     }
     newseriesnames <- getnewcolumns(gg$data[[panel]], mergeddata)
     gg$data[[panel]] <- mergeddata

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -377,5 +377,15 @@ expect_error(print(bar), NA)
 foo <- data.frame(x=1:3,b=c("a","b","a"),y=1:3)
 expect_error(arphitgg(foo,agg_aes(x=x,y=y,facet=b)) + agg_line(), NA)
 
+# Variables with spaces
+library(tibble)
+foo <- tibble(x=1:10, `A spaced title` = rnorm(10), y = rnorm(10))
+expect_error(print(arphitgg(foo, agg_aes(x=x,y=`A spaced title`))+agg_line()), NA)
+bar <- tibble(`spaced x`=1:10,
+                         `spaced y`=1:10,
+                         `spaced group`=c("a","a","b","b","a","a","a","b","b","b"),
+                         `spaced facet`=c("c","c","c","c","d","d","d","d","d","d"))
+arphitgg(bar, agg_aes(x = `spaced x`, y = `spaced y`, group = `spaced group`, facet = `spaced facet`)) + agg_line()
+
 # Shutdown any devices
 graphics.off()


### PR DESCRIPTION
Some dplyr verbs need backticks around variables with spaces.

Closes #97 