### PR TITLE
Resize ticks to account for multipanels

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -206,7 +206,20 @@ inchesasuser <- function(x) {
   x*graphics::strheight("AA",units="user")/graphics::strheight("AA",units="inches")
 }
 
-gridsandborders <- function(p, layout, portrait, yunits, xunits, yticks, xlabels, ylim, xlim, dropxlabel, srt) {
+tickadjustment <- function(layout) {
+  return(switch(layout,
+                "1" = 1,
+                "2h" = 2,
+                "2v" = 3/2,
+                "2b2" = 2,
+                "3h" = 3,
+                "3v" = 2,
+                "3b2" = 3,
+                "4h" = 4,
+                "4b2" = 4))
+}
+
+gridsandborders <- function(p, layout, yunits, xunits, yticks, xlabels, ylim, xlim, dropxlabel, srt) {
   side <- getsides(p, layout)
   xlab <- needxlabels(p, layout)
 
@@ -230,7 +243,7 @@ gridsandborders <- function(p, layout, portrait, yunits, xunits, yticks, xlabels
   ## Draw the x-axis
   if (xlab) {
     # Draw x ticks and labels
-    graphics::axis(1, xlabels$ticks, tck = DEFAULTTICKLENGTH, labels = FALSE)
+    graphics::axis(1, xlabels$ticks, tck = tickadjustment(layout)*DEFAULTTICKLENGTH, labels = FALSE)
     if (dropfirstxlabel(p, layout, dropxlabel)) {
       at <- xlabels$at[2:length(xlabels$at)]
       labels <- xlabels$labels[2:length(xlabels$labels)]
@@ -369,7 +382,7 @@ getxvals <- function(data, ists, xvals) {
   }
 }
 
-drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, margins, layout, portrait, attributes, yunits, xunits, yticks, xlabels, ylim, xlim, paneltitle, panelsubtitle, yaxislabel, xaxislabel, bar.stacked, dropxlabel, joined, srt, xtickmargin) {
+drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, margins, layout, attributes, yunits, xunits, yticks, xlabels, ylim, xlim, paneltitle, panelsubtitle, yaxislabel, xaxislabel, bar.stacked, dropxlabel, joined, srt, xtickmargin) {
   # Basic set up
   graphics::par(mar = c(0, 0, 0, 0))
   l <- getlocation(p, layout)
@@ -388,7 +401,7 @@ drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, m
 
   drawbgshadings(bgshadings, p)
 
-  gridsandborders(p, layout, portrait, yunits, xunits, yticks, xlabels, ylim, xlim, dropxlabel, srt)
+  gridsandborders(p, layout, yunits, xunits, yticks, xlabels, ylim, xlim, dropxlabel, srt)
 
   drawbars(l, series, bars, data, x, attributes, xlim, ylim, bar.stacked)
 

--- a/R/main.R
+++ b/R/main.R
@@ -120,7 +120,7 @@ arphit <- function(data, series = NULL, x = NULL, layout = "1", bars = NULL, fil
 
   # Plot each panel
   for (p in names(panels)) {
-    drawpanel(p, panels[[p]], bars[[p]], data[[p]], xvars[[p]], !is.null(xvars[[paste0(p,"ts")]]), shading[[p]], bgshading, margins, layout, portrait, attributes[[p]], yunits[[p]], xunits[[p]], yticks[[p]], xlabels[[p]], ylim[[p]], xlim[[p]], paneltitles[[p]], panelsubtitles[[p]], yaxislabels[[p]], xaxislabels[[p]], bar.stacked, dropxlabel, joined, srt, margins$xtickmargin)
+    drawpanel(p, panels[[p]], bars[[p]], data[[p]], xvars[[p]], !is.null(xvars[[paste0(p,"ts")]]), shading[[p]], bgshading, margins, layout, attributes[[p]], yunits[[p]], xunits[[p]], yticks[[p]], xlabels[[p]], ylim[[p]], xlim[[p]], paneltitles[[p]], panelsubtitles[[p]], yaxislabels[[p]], xaxislabels[[p]], bar.stacked, dropxlabel, joined, srt, margins$xtickmargin)
   }
 
   # Draw outer material

--- a/tests/testthat/test-draw-panel.R
+++ b/tests/testthat/test-draw-panel.R
@@ -205,3 +205,14 @@ expect_equal(getxvals(data.frame(),TRUE,seq(from=2000.125,by=0.25,length.out = 1
 expect_equal(getxvals(data.frame(),FALSE,1:10), 1.5:10.5)
 expect_equal(getxvals(data.frame(),FALSE,c(2,4,6,8)), c(3,5,7,9))
 expect_equal(getxvals(data.frame(),FALSE,letters[1:4]), 1.5:4.5)
+
+# tick adjustment (#100)
+expect_equal(tickadjustment("1"), 1)
+expect_equal(tickadjustment("2v"), 3/2) # seems like a weird bug in R, shouldn't be needed, but shows up better this way...
+expect_equal(tickadjustment("2h"), 2)
+expect_equal(tickadjustment("2b2"), 2)
+expect_equal(tickadjustment("3v"), 2) # seems like a weird bug in R, shouldn't be needed, but shows up better this way...
+expect_equal(tickadjustment("3h"), 3)
+expect_equal(tickadjustment("3b2"), 3)
+expect_equal(tickadjustment("4h"), 4)
+expect_equal(tickadjustment("4b2"), 4)


### PR DESCRIPTION
Ticks were getting squashed down with multipanel charts, and so were too small. Have added in correction factors.

Closes #100 