### PR TITLE
Fix display of multiline footnotes

### DIFF
--- a/R/draw-outer.R
+++ b/R/draw-outer.R
@@ -113,22 +113,40 @@ drawnotes <- function(footnotes, sources, notesstart) {
   if (nf > 0 ) {
     for (i in 1:nf) {
       nlines <- stringr::str_count(footnotes[[i]], "\n")
-      replacedtext <- stringr::str_replace_all(footnotes[[i]], "\n", paste("\n", strrep(" ", NSPACESNOTES), sep = ""))
-      graphics::mtext(strrep("*", i), outer = TRUE, side = 1, adj = 0, line = cumuloffset + 1.1*(i-1), cex = (14/20))
-      graphics::mtext(paste(strrep(" ", NSPACESNOTES), replacedtext, sep = ""), outer = TRUE, side = 1, adj = 0, line = cumuloffset + (i-1), cex = (14/20))
+      replacedtext <- stringr::str_replace_all(footnotes[[i]], "\n", paste0("\n", strrep(" ", NSPACESNOTES)))
+      graphics::mtext(strrep("*", i),
+                      outer = TRUE,
+                      side = 1,
+                      adj = 0,
+                      padj = 1,
+                      line = cumuloffset + 1.1*(i-1) - 1, # Minus 1 becuase padj = 1
+                      cex = (14/20))
+      graphics::mtext(paste(strrep(" ", NSPACESNOTES), replacedtext, sep = ""),
+                      outer = TRUE,
+                      side = 1,
+                      adj = 0,
+                      padj = 1,
+                      line = cumuloffset + 1.1*(i-1) - 1, # Minus 1 becuase padj = 1
+                      cex = (14/20))
       cumuloffset <- cumuloffset + 1.1*nlines
     }
   }
   if (nchar(sources$text) > 0) {
     if (sources$plural) {
-      graphics::mtext("Sources:", outer = TRUE, side = 1, adj = 0, line = cumuloffset + 1.1*nf, cex = (14/20))
+      graphics::mtext("Sources:", outer = TRUE, side = 1, adj = 0, padj = 1, line = cumuloffset + 1.1*nf - 1, cex = (14/20))
     } else {
-      graphics::mtext("Source:", outer = TRUE, side = 1, adj = 0, line = cumuloffset + 1.1*nf, cex = (14/20))
+      graphics::mtext("Source:", outer = TRUE, side = 1, adj = 0, padj = 1, line = cumuloffset + 1.1*nf - 1, cex = (14/20))
     }
 
     nlines <- stringr::str_count(sources$text, "\n")
     replacedtext <- stringr::str_replace_all(sources$text, "\n", paste("\n", strrep(" ", NSPACESSOURCES), sep = ""))
-    graphics::mtext(paste(strrep(" ", NSPACESSOURCES), replacedtext, sep = ""), outer = TRUE, side = 1, adj = 0, line = cumuloffset + 1.1*nf, cex = (14/20))
+    graphics::mtext(paste0(strrep(" ", NSPACESSOURCES), replacedtext),
+                    outer = TRUE,
+                    side = 1,
+                    adj = 0,
+                    padj = 1,
+                    line = cumuloffset + 1.1*nf - 1,
+                    cex = (14/20))
   }
   graphics::par(lheight = 1)
 }


### PR DESCRIPTION
Add padj = 1 to correctly line up long footnotes

Closes #103 