### PR TITLE
Bring axis labels closer to axes

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -81,11 +81,11 @@ drawaxislabels <- function(ylabel, xlabel, p, layout, xtickmargin) {
   if (!is.null(ylabel)) {
     side <- getsides(p, layout)
     if (!is.na(side) && side == 2) {
-      graphics::mtext(text = ylabel, side = side, line = 2.5, las = 3)
+      graphics::mtext(text = ylabel, side = side, line = 1.8, las = 3)
     }
   }
   if (!is.null(xlabel) && needxlabels(p, layout)) {
-    graphics::mtext(text = xlabel, side = 1, line = (xtickmargin+0.2))
+    graphics::mtext(text = xlabel, side = 1, line = (xtickmargin-0.5))
   }
 }
 

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -81,7 +81,7 @@ drawaxislabels <- function(ylabel, xlabel, p, layout, xtickmargin) {
   if (!is.null(ylabel)) {
     side <- getsides(p, layout)
     if (!is.na(side) && side == 2) {
-      graphics::mtext(text = ylabel, side = side, line = 2.4, las = 3)
+      graphics::mtext(text = ylabel, side = side, line = 2.5, las = 3)
     }
   }
   if (!is.null(xlabel) && needxlabels(p, layout)) {

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -81,7 +81,7 @@ drawaxislabels <- function(ylabel, xlabel, p, layout, xtickmargin) {
   if (!is.null(ylabel)) {
     side <- getsides(p, layout)
     if (!is.na(side) && side == 2) {
-      graphics::mtext(text = ylabel, side = side, line = 1.8, las = 3)
+      graphics::mtext(text = ylabel, side = side, line = 2.4, las = 3)
     }
   }
   if (!is.null(xlabel) && needxlabels(p, layout)) {

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -77,11 +77,11 @@ drawpaneltitle <- function(paneltitle, panelsubtitle) {
   }
 }
 
-drawaxislabels <- function(ylabel, xlabel, p, layout, xtickmargin) {
+drawaxislabels <- function(ylabel, xlabel, p, layout, xtickmargin, leftmargin) {
   if (!is.null(ylabel)) {
     side <- getsides(p, layout)
     if (!is.na(side) && side == 2) {
-      graphics::mtext(text = ylabel, side = side, line = 2.5, las = 3)
+      graphics::mtext(text = ylabel, side = side, line = leftmargin - 2, las = 3)
     }
   }
   if (!is.null(xlabel) && needxlabels(p, layout)) {
@@ -382,7 +382,7 @@ getxvals <- function(data, ists, xvals) {
   }
 }
 
-drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, margins, layout, attributes, yunits, xunits, yticks, xlabels, ylim, xlim, paneltitle, panelsubtitle, yaxislabel, xaxislabel, bar.stacked, dropxlabel, joined, srt, xtickmargin) {
+drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, margins, layout, attributes, yunits, xunits, yticks, xlabels, ylim, xlim, paneltitle, panelsubtitle, yaxislabel, xaxislabel, bar.stacked, dropxlabel, joined, srt) {
   # Basic set up
   graphics::par(mar = c(0, 0, 0, 0))
   l <- getlocation(p, layout)
@@ -412,5 +412,5 @@ drawpanel <- function(p, series, bars, data, xvals, ists, shading, bgshadings, m
   drawlines(l, series, bars, data, x, attributes, xlim, ylim, joined)
 
   drawpaneltitle(paneltitle, panelsubtitle)
-  drawaxislabels(yaxislabel, xaxislabel, p, layout, xtickmargin)
+  drawaxislabels(yaxislabel, xaxislabel, p, layout, margins$xtickmargin, margins$left)
 }

--- a/R/main.R
+++ b/R/main.R
@@ -121,7 +121,7 @@ agg_qplot <- function(data, series = NULL, x = NULL, layout = "1", bars = NULL, 
 
   # Plot each panel
   for (p in names(panels)) {
-    drawpanel(p, panels[[p]], bars[[p]], data[[p]], xvars[[p]], !is.null(xvars[[paste0(p,"ts")]]), shading[[p]], bgshading, margins, layout, attributes[[p]], yunits[[p]], xunits[[p]], yticks[[p]], xlabels[[p]], ylim[[p]], xlim[[p]], paneltitles[[p]], panelsubtitles[[p]], yaxislabels[[p]], xaxislabels[[p]], bar.stacked, dropxlabel, joined, srt, margins$xtickmargin)
+    drawpanel(p, panels[[p]], bars[[p]], data[[p]], xvars[[p]], !is.null(xvars[[paste0(p,"ts")]]), shading[[p]], bgshading, margins, layout, attributes[[p]], yunits[[p]], xunits[[p]], yticks[[p]], xlabels[[p]], ylim[[p]], xlim[[p]], paneltitles[[p]], panelsubtitles[[p]], yaxislabels[[p]], xaxislabels[[p]], bar.stacked, dropxlabel, joined, srt)
   }
 
   # Draw outer material


### PR DESCRIPTION
Closes #113 

- [ ] Should use a measure of y padding to determine how far to place y axis label. Is currently hardcoded, so doesn't take into account width of y ticks and units