### PR TITLE
Larger line spacing in legends

### DIFF
--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -124,7 +124,7 @@ figuresetup <- function(filename, device, panels, xticks, yticks, yunits, title,
     notesstart <- notesstart + (legend.nrow-1)*1.2 + 2.5
   }
 
-  xtickmargin <- 2 + xticksize(xticks, layout, srt)
+  xtickmargin <- 1.5 + xticksize(xticks, layout, srt)
   notesstart <- notesstart + xtickmargin
 
   bottom <- countfnlines(footnotes) + countsrclines(sources) + notesstart

--- a/R/draw-outer.R
+++ b/R/draw-outer.R
@@ -103,7 +103,8 @@ drawlegend <- function(panels, bars, attributes, ncol, xtickmargin, hasaxislabel
                    col = col,
                    fill = fill,
                    border = border,
-                   cex = (18/20))
+                   cex = (18/20),
+                   y.intersp = 1.4)
 }
 
 drawnotes <- function(footnotes, sources, notesstart) {

--- a/tests/testthat/test-draw-figure.R
+++ b/tests/testthat/test-draw-figure.R
@@ -57,8 +57,8 @@ for (suffix in c("png","pdf","emf")) {
 # tests for bottom spacing
 fakeseries1 <- c("a","b")
 onesided <- handlepanels(fakeseries1, "1")
-expect_equal(figuresetup("", NULL, onesided, list(), list(), list("1" = "%"), NULL, NULL, NULL, list(text = "", plural = FALSE), list(), list(), 0, LANDSCAPESIZE, FALSE, "1", 0)$notesstart, 2)
-expect_equal(figuresetup("", NULL, onesided, list(), list(), list("1" = "%"), NULL, NULL, NULL, list(text = "", plural = FALSE), list(), list("1" = "test"), 0, LANDSCAPESIZE, FALSE, "1", 0)$notesstart, 3.7)
+expect_equal(figuresetup("", NULL, onesided, list(), list(), list("1" = "%"), NULL, NULL, NULL, list(text = "", plural = FALSE), list(), list(), 0, LANDSCAPESIZE, FALSE, "1", 0)$notesstart, 1.5)
+expect_equal(figuresetup("", NULL, onesided, list(), list(), list("1" = "%"), NULL, NULL, NULL, list(text = "", plural = FALSE), list(), list("1" = "test"), 0, LANDSCAPESIZE, FALSE, "1", 0)$notesstart, 3.2)
 
 # tests for extra margins when have y axis labels
 noaxislabelmargin <- figuresetup("", NULL, onesided, list(), list(), list("1" = "%"), NULL, NULL, NULL, list(text = "", plural = FALSE), list(), list(), 0,  LANDSCAPESIZE, FALSE, "1", 0)$left


### PR DESCRIPTION
Lines were previously too tight, meaning text overlapped. Closes #107 