### PR TITLE
Bug fix in autolabeller

### DIFF
--- a/R/autolabel-collisions.R
+++ b/R/autolabel-collisions.R
@@ -48,7 +48,7 @@ grid.collision <- function(text, x, y, xlim, ylim, ylim_n) {
 }
 
 series.collision <- function(text, x, y, series.x, data, series) {
-  series.y <- data[, series]
+  series.y <- data[[series]]
   for (i in 1:(length(series.x)-1)) {
     a1 <- series.x[[i]]
     b1 <- series.y[[i]]

--- a/R/autolabel-distances.R
+++ b/R/autolabel-distances.R
@@ -37,7 +37,7 @@ lineofsight <- function(x, y, a, b, xvar, data, serieslist, thisseries) {
   los <- TRUE
   for (s in serieslist) {
     if (s != thisseries) {
-      block.y <- data[, s]
+      block.y <- data[[s]]
       los <- los && lineofsight.point2point(x, y, a, b, xvar, block.y)
     }
   }
@@ -45,7 +45,7 @@ lineofsight <- function(x, y, a, b, xvar, data, serieslist, thisseries) {
 }
 
 series.distance <- function(a, b, series.x, data, serieslist, thisseries, requirelos) {
-  series.y <- data[, thisseries]
+  series.y <- data[[thisseries]]
   distance <- Inf
   px <- NULL
   py <- NULL

--- a/R/autolabel-simulation.R
+++ b/R/autolabel-simulation.R
@@ -35,7 +35,7 @@ seriesforce <- function(a, b, series.x, series.y) {
 calculate.seriesforces <- function(x, data, labelsmap, label, a, b) {
   vector <- c(0, 0)
   for (s in names(labelsmap)) {
-    y <- data[, s]
+    y <- data[[s]]
     vector <- vector + seriesforce(a, b, x, y)
   }
   return(vector)
@@ -145,7 +145,7 @@ labelsimulation <- function(series.x, data, labelsmap, xlim, ylim, ylim_n) {
   ap <- sampleanchorpoints(data, labelsmap)
 
   for (label in names(labelsmap)) {
-    anchor <- c(series.x[ap[[label]]], data[ap[[label]], label])
+    anchor <- c(series.x[ap[[label]]], data[[ap[[label]], label]])
     labellocations[[label]] <- location.fromanchor(label, anchor, series.x, reduceddata, data, labelsmap, labellocations, xlim, ylim, ylim_n)
   }
   return(labellocations)

--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -18,6 +18,10 @@ autolabel <- function(xvals, data, panels, shading, layout, xlim_list, ylim_list
         # Handling the x variables
         ists <- !is.null(xvals[[paste0(p,"ts")]])
         x <- getxvals(data[[p]], ists, xvals[[p]])
+        if (stats::is.ts(data[[p]])) {
+          # because indexing into time series data doesn't work with [[seriesname]]
+          data[[p]] <- as.data.frame(data[[p]])
+        }
 
         xlim <- xlim_list[[p]]
         ylim <- c(ylim_list[[p]]$min, ylim_list[[p]]$max)

--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -16,7 +16,7 @@ autolabel <- function(xvals, data, panels, shading, layout, xlim_list, ylim_list
       if (length(labelsmap) > 1) {
         data[[p]] <- convertdata.axes(data, panels, p, layout, ylim_list)
         # Handling the x variables
-        ists <- !is.null(paste0(p, "ts"))
+        ists <- !is.null(xvals[[paste0(p,"ts")]])
         x <- getxvals(data[[p]], ists, xvals[[p]])
 
         xlim <- xlim_list[[p]]
@@ -29,10 +29,10 @@ autolabel <- function(xvals, data, panels, shading, layout, xlim_list, ylim_list
         graphics::plot(0, lwd = 0, pch = NA, axes = FALSE, xlab = "", ylab = "", xlim = xlim, ylim = ylim)
 
         ## TODO: Add collisions for bg shading, lines and arrows
-        candidates <- findcandidates(xvals[[p]], data[[p]], labelsmap, xlim, ylim, ylim_n)
+        candidates <- findcandidates(x, data[[p]], labelsmap, xlim, ylim, ylim_n)
         locations <- bestcandidate(candidates, x, data[[p]], labelsmap)
         newlabels <- append(newlabels, formatlabels(locations, labelsmap, attributes, p, layout))
-        newarrows <- append(newarrows, addarrows(xvals[[p]], data[[p]], panels, labelsmap, locations, attributes[[p]]$col, p))
+        newarrows <- append(newarrows, addarrows(x, data[[p]], panels, labelsmap, locations, attributes[[p]]$col, p))
         if (length(locations) < length(labelsmap)) {
           warning("Unable to find locations for some series labels.")
         }

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -2,4 +2,17 @@ context("Autolabeller - miscellaneous tests")
 foo <- data.frame(x = 1:50, y = rnorm(50), y2 = rnorm(50))
 
 p <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y)) + agg_line(agg_aes(x=x,y=y2)) + agg_autolabel()
-print(p)
+expect_error(
+  print(p),
+  NA
+)
+
+# Non-numeric anchor point (#122)
+data <- tibble::tibble(x = sort(rep(letters[1:5],2)), g = rep(c("f","m"),5), y = rnorm(10))
+p <-  arphitgg(data, agg_aes(x=x,y=y,group=g)) +
+  agg_col() +
+  agg_autolabel()
+expect_error(
+  print(p),
+  NA
+)

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -16,3 +16,13 @@ expect_error(
   print(p),
   NA
 )
+
+# Factors in data for auto labeller (#123)
+p <- data.frame(x = sort(rep(letters[1:5],2)), g = rep(c("f","m"),5), y = rnorm(10)) %>% 
+  arphitgg(agg_aes(x=x,y=y,group=g)) +
+  agg_col() +
+  agg_autolabel()
+expect_error(
+  print(p),
+  NA
+)


### PR DESCRIPTION
Incorrect handling of `ists`, leading to non-numeric anchor point

Closes #122 and #123 