### PR TITLE
Better display of x labels with non-zero srt

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -256,14 +256,18 @@ gridsandborders <- function(p, layout, yunits, xunits, yticks, xlabels, ylim, xl
       labels <- xlabels$labels[1:(length(xlabels$labels)-1)]
       graphics::mtext(text = xunits, side = 1, at = xlim[2], line = 0, cex = 1, padj = 1)
     }
-    # Calculate what one line is in user coordinates
-    y <- inchesasuser(1.8 * CSI)
-    y <- ylim$min - y
+
     if (srt == 0) {
       adj <- c(0.5, 0)
+      # Calculate what one line is in user coordinates
+      y <- inchesasuser(1.8 * CSI)
     } else {
       adj <- c(1, 0.5)
+      # Calculate what one line is in user coordinates
+      y <- inchesasuser(0.8 * CSI)
     }
+
+    y <- ylim$min - y
     graphics::text(x = at, y = y, labels = labels, cex = 1, adj = adj, srt = srt, xpd = NA)
   }
 

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -260,11 +260,11 @@ gridsandborders <- function(p, layout, yunits, xunits, yticks, xlabels, ylim, xl
     y <- inchesasuser(1.8 * CSI)
     y <- ylim$min - y
     if (srt == 0) {
-      adj <- 0.5
+      adj <- c(0.5, 0)
     } else {
-      adj <- 1
+      adj <- c(1, 0.5)
     }
-    graphics::text(x = at, y = y, labels = labels, cex = 1, adj = c(adj,0), srt = srt, xpd = NA)
+    graphics::text(x = at, y = y, labels = labels, cex = 1, adj = adj, srt = srt, xpd = NA)
   }
 
   ## Draw the grid


### PR DESCRIPTION
- Put non-horizontal x-labels in the center of the tick
- Move non-horizontal x-labels closer to the axis

Closes #137 