### PR TITLE
Handle NAs in autolabeller

### DIFF
--- a/R/autolabel-collisions.R
+++ b/R/autolabel-collisions.R
@@ -1,6 +1,6 @@
 linesegment.intersect <- function(x1, y1, x2, y2, a1, b1, a2, b2) {
   if (is.na(x1) || is.na(y1) || is.na(x2) || is.na(y2) || is.na(a1) || is.na(b1) || is.na(a2) || is.na(b2)) {
-    stop("huh")
+    return(FALSE)
   }
   if (max(x1, x2) < min(a1, a2) || min(x1, x2) > max(a1, a2) || max(y1, y2) < min(b1, b2) || min(y1, y2) > max(b1, b2)) {
     return(FALSE)

--- a/R/autolabel-distances.R
+++ b/R/autolabel-distances.R
@@ -1,27 +1,31 @@
 pointlinedistance <- function(x, y, x1, y1, x2, y2) {
-  A <- x - x1
-  B <- y - y1
-  C <- x2 - x1
-  D <- y2 - y1
-
-  dot <- A * C + B * D
-  len_sq <- C * C + D * D
-  param <- -1
-  if (len_sq != 0) {
-    param = dot / len_sq
-  }
-
-  if (param < 0) {
-    xx <- x1
-    yy <- y1
-  } else if (param > 1) {
-    xx <- x2
-    yy <- y2
+  if(is.na(x) || is.na(y) || is.na(x1) || is.na(y1) || is.na(x2) || is.na(y2)) {
+    return(list(dist = Inf, x = NA, y = NA))
   } else {
-    xx <- x1 + param * C
-    yy <- y1 + param * D
+    A <- x - x1
+    B <- y - y1
+    C <- x2 - x1
+    D <- y2 - y1
+
+    dot <- A * C + B * D
+    len_sq <- C * C + D * D
+    param <- -1
+    if (len_sq != 0) {
+      param <- dot / len_sq
+    }
+
+    if (param < 0) {
+      xx <- x1
+      yy <- y1
+    } else if (param > 1) {
+      xx <- x2
+      yy <- y2
+    } else {
+      xx <- x1 + param * C
+      yy <- y1 + param * D
+    }
+    return (list(dist = distanceininches(x, y, xx, yy), x = xx, y = yy))
   }
-  return (list(dist = distanceininches(x, y, xx, yy), x = xx, y = yy))
 }
 
 lineofsight.point2point <- function(x, y, a, b, block.x, block.y) {

--- a/R/autolabel-simulation.R
+++ b/R/autolabel-simulation.R
@@ -158,7 +158,7 @@ labelsimulation <- function(series.x, data, labelsmap, xlim, ylim, ylim_n) {
 
   for (label in names(labelsmap)) {
     # Get an anchor point for this label
-    anchor <- sampleanchorpoints(data, series.x, labelsmap[[label]])
+    anchor <- sampleanchorpoints(data, series.x, label)
     labellocations[[label]] <- location.fromanchor(label, anchor, series.x, reduceddata, data, labelsmap, labellocations, xlim, ylim, ylim_n)
   }
   return(labellocations)

--- a/tests/testthat/test-autolabel-collisions.R
+++ b/tests/testthat/test-autolabel-collisions.R
@@ -9,7 +9,9 @@ plot(1:10,1:10)
 expect_true(linesegment.intersect(0,0,1,1,0,1,1,0))
 expect_true(linesegment.intersect(10,10,10,0,0,4,20,4))
 expect_false(linesegment.intersect(0,0,1,1,10,10,12,12))
-expect_error(linesegment.intersect(0,0,1,1,10,10,12,NA))
+expect_false(linesegment.intersect(0,0,1,1,10,10,12,NA))
+expect_false(linesegment.intersect(0,0,1,1,NA,10,12,12))
+expect_false(linesegment.intersect(NA,0,1,1,10,10,12,12))
 expect_true(linesegment.intersect(0,0,1,1,0,1,1,1))
 
 # Text bounding box

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -26,3 +26,40 @@ expect_error(
   print(p),
   NA
 )
+
+context("Autolabeller - miscellaneous tests")
+foo <- data.frame(x = 1:50, y = rnorm(50), y2 = rnorm(50))
+
+p <- arphitgg(foo) + agg_line(agg_aes(x=x,y=y)) + agg_line(agg_aes(x=x,y=y2)) + agg_autolabel()
+expect_error(
+  print(p),
+  NA
+)
+
+# Non-numeric anchor point (#122)
+data <- tibble::tibble(x = sort(rep(letters[1:5],2)), g = rep(c("f","m"),5), y = rnorm(10))
+p <-  arphitgg(data, agg_aes(x=x,y=y,group=g)) +
+  agg_col() +
+  agg_autolabel()
+expect_error(
+  print(p),
+  NA
+)
+
+# Factors in data for auto labeller (#123)
+p <- data.frame(x = sort(rep(letters[1:5],2)), g = rep(c("f","m"),5), y = rnorm(10)) %>%
+  arphitgg(agg_aes(x=x,y=y,group=g)) +
+  agg_col() +
+  agg_autolabel()
+expect_error(
+  print(p),
+  NA
+)
+
+# NAs in data for autolabeller (#126)
+foo <- tibble(year = 2000:2020, y = rnorm(21),y2=rnorm(21))
+foo$y[1:10] <- NA
+expect_error(
+  agg_qplot(foo, x="year", enable_autolabeller = TRUE),
+  NA
+)

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -57,7 +57,7 @@ expect_error(
 )
 
 # NAs in data for autolabeller (#126)
-foo <- tibble(year = 2000:2020, y = rnorm(21),y2=rnorm(21))
+foo <- tibble::tibble(year = 2000:2020, y = rnorm(21),y2=rnorm(21))
 foo$y[1:10] <- NA
 expect_error(
   agg_qplot(foo, x="year", enable_autolabeller = TRUE),


### PR DESCRIPTION
Adds checks for NAs in data and correctly ignores or handles.

Fixes #126 