### PR TITLE
Top align x labels

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -257,14 +257,13 @@ gridsandborders <- function(p, layout, yunits, xunits, yticks, xlabels, ylim, xl
       graphics::mtext(text = xunits, side = 1, at = xlim[2], line = 0, cex = 1, padj = 1)
     }
 
+    # Calculate what one line is in user coordinates
+    y <- inchesasuser(0.8 * CSI)
+
     if (srt == 0) {
-      adj <- c(0.5, 0)
-      # Calculate what one line is in user coordinates
-      y <- inchesasuser(1.8 * CSI)
+      adj <- c(0.5, 1)
     } else {
       adj <- c(1, 0.5)
-      # Calculate what one line is in user coordinates
-      y <- inchesasuser(0.8 * CSI)
     }
 
     y <- ylim$min - y


### PR DESCRIPTION
Means multi-line x labels flow downwards, rather than flowing onto the graph.

Fixes #141