### PR TITLE
Set RNG seed in tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,6 @@
 library(testthat)
 library(arphit)
 
+set.seed(42) # So that autolabeller coverage results are deterministic
+
 test_check("arphit")


### PR DESCRIPTION
Ensures coverage in autolabeller tests is deterministic, rather than random across runs.