### PR TITLE
Widen x values for missing dates in bar plots

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -359,7 +359,7 @@ drawbars <- function(l, series, bars, data, x, ists, freq, attributes, xlim, yli
       equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))
       x <- seq(from = min(x), to = max(x), by = freq) # and replace x
       bardata <- dplyr::arrange_(dplyr::full_join(bardata, equal_spaced, by = "x"), "x")
-      bardata <- dpyr::select_(bardata, "-x")
+      bardata <- dplyr::select_(bardata, "-x")
     }
     bardata <- t(as.matrix(bardata))
     bardata[is.na(bardata)] <- 0 # singletons don't show otherwise (#82)

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -359,7 +359,7 @@ drawbars <- function(l, series, bars, data, x, ists, freq, attributes, xlim, yli
       equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))
       x <- seq(from = min(x), to = max(x), by = freq) # and replace x
       bardata <- dplyr::arrange_(dplyr::full_join(bardata, equal_spaced, by = "x"), "x")
-      bardata <- select_(bardata, "-x")
+      bardata <- dpyr::select_(bardata, "-x")
     }
     bardata <- t(as.matrix(bardata))
     bardata[is.na(bardata)] <- 0 # singletons don't show otherwise (#82)

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -353,13 +353,14 @@ drawbars <- function(l, series, bars, data, x, ists, freq, attributes, xlim, yli
   }
   if (length(barcolumns) > 0) {
     bardata <- data[, barcolumns, drop = FALSE]
-    # Widen if we are missing x values (otherwise the bars are in the wrong spot (#157))
-    bardata$x <- x
-    equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))
-    x <- seq(from = min(x), to = max(x), by = freq) # and replace x
-    bardata <- dplyr::arrange_(full_join(bardata, equal_spaced, by = "x"), "x")
-    bardata <- select_(bardata, "-x")
-
+    if (!is.null(freq)) {
+      # Widen if we are missing x values (otherwise the bars are in the wrong spot (#157))
+      bardata$x <- x
+      equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))
+      x <- seq(from = min(x), to = max(x), by = freq) # and replace x
+      bardata <- dplyr::arrange_(full_join(bardata, equal_spaced, by = "x"), "x")
+      bardata <- select_(bardata, "-x")
+    }
     bardata <- t(as.matrix(bardata))
     bardata[is.na(bardata)] <- 0 # singletons don't show otherwise (#82)
     # Split into positive and negative (R doesn't stack well across axes)

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -358,7 +358,7 @@ drawbars <- function(l, series, bars, data, x, ists, freq, attributes, xlim, yli
       bardata$x <- x
       equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))
       x <- seq(from = min(x), to = max(x), by = freq) # and replace x
-      bardata <- dplyr::arrange_(full_join(bardata, equal_spaced, by = "x"), "x")
+      bardata <- dplyr::arrange_(dplyr::full_join(bardata, equal_spaced, by = "x"), "x")
       bardata <- select_(bardata, "-x")
     }
     bardata <- t(as.matrix(bardata))

--- a/R/main.R
+++ b/R/main.R
@@ -67,7 +67,34 @@ agg_draw_internal <- function(data, series = NULL, x = NULL, layout = "1", bars 
 
   # Plot each panel
   for (p in names(panels)) {
-    drawpanel(p, panels[[p]], bars[[p]], data[[p]], xvals[[p]], !is.null(xvals[[paste0(p,"ts")]]), shading[[p]], bgshading, margins, layout, attributes[[p]], yunits[[p]], xunits[[p]], yticks[[p]], xlabels[[p]], ylim[[p]], xlim[[p]], paneltitles[[p]], panelsubtitles[[p]], yaxislabels[[p]], xaxislabels[[p]], bar.stacked, dropxlabel, joined, srt)
+    drawpanel(
+      p,
+      panels[[p]],
+      bars[[p]],
+      data[[p]],
+      xvals[[p]],
+      !is.null(xvals[[paste0(p, "ts")]]),
+      xvals[[paste0(p, "freq")]],
+      shading[[p]],
+      bgshading,
+      margins,
+      layout,
+      attributes[[p]],
+      yunits[[p]],
+      xunits[[p]],
+      yticks[[p]],
+      xlabels[[p]],
+      ylim[[p]],
+      xlim[[p]],
+      paneltitles[[p]],
+      panelsubtitles[[p]],
+      yaxislabels[[p]],
+      xaxislabels[[p]],
+      bar.stacked,
+      dropxlabel,
+      joined,
+      srt
+    )
   }
 
   # Draw outer material

--- a/R/xvars.R
+++ b/R/xvars.R
@@ -27,9 +27,11 @@ get_x_values <- function(data, x) {
         outx[[p]] <- data[[p]][[x[[p]]]]
         # if is dates, convert to year fractions
         if (lubridate::is.Date(outx[[p]])) {
-          outx[[p]] <- make_decimal_date(outx[[p]], frequencyof(outx[[p]]))
+          freq <- frequencyof(outx[[p]])
+          outx[[p]] <- make_decimal_date(outx[[p]], freq)
           # Add a little helper to tell other functions we have time series data
           outx[[paste0(p, "ts")]] <- TRUE
+          outx[[paste0(p, "freq")]] <- freq
         }
       } else {
         stop(paste0("The x variable you supplied for panel ", p, " (" , x[[p]], ") is not a variable in the data you supplied."))

--- a/tests/testthat/test-xvars.R
+++ b/tests/testthat/test-xvars.R
@@ -22,21 +22,77 @@ expect_error(get_x_values(tibbledata, NULL),
 expect_error(get_x_values(tibbledata, list("1" = "foo")))
 
 # Supply x value for each panel
-offsetdates <- seq(from = 2000.125, by = 0.25, length.out = 12)
-expect_equal(get_x_values(dfdata, x = list("1" = "date")), list("1" = offsetdates, "1ts" = TRUE))
-expect_equal(get_x_values(tibbledata, x = list("1" = "date")), list("1" = offsetdates, "1ts" = TRUE))
+offsetdates <- seq(from = 2000.125,
+                   by = 0.25,
+                   length.out = 12)
+expect_equal(get_x_values(dfdata, x = list("1" = "date")),
+             list(
+               "1" = offsetdates,
+               "1ts" = TRUE,
+               "1freq" = 0.25
+             ))
+expect_equal(get_x_values(tibbledata, x = list("1" = "date")),
+             list(
+               "1" = offsetdates,
+               "1ts" = TRUE,
+               "1freq" = 0.25
+             ))
 # Supply an x for all panels
-expect_equal(get_x_values(dfdata, x = list("1" = "date")), list("1" = offsetdates, "1ts" = TRUE))
-expect_equal(get_x_values(tibbledata, x = list("1" = "date")), list("1" = offsetdates, "1ts" = TRUE))
+expect_equal(get_x_values(dfdata, x = list("1" = "date")),
+             list(
+               "1" = offsetdates,
+               "1ts" = TRUE,
+               "1freq" = 0.25
+             ))
+expect_equal(get_x_values(tibbledata, x = list("1" = "date")),
+             list(
+               "1" = offsetdates,
+               "1ts" = TRUE,
+               "1freq" = 0.25
+             ))
 
 # supply multiple datasets and multiple x variables
-offsetdates <- seq(from = 2000.125, by = 0.25, length.out = 12)
-dfdata <- data.frame(date = seq.Date(from = as.Date("2000-01-01"), length.out = 12, by = "quarter"), x1 = rnorm(12), x2 = rnorm(12), x3 = rnorm(12, sd = 10), x4 = rnorm(12, sd = 5))
-dfdata2 <- data.frame(date2 = seq.Date(from = as.Date("2000-01-01"), length.out = 12, by = "quarter"), x1 = rnorm(12), x2 = rnorm(12), x3 = rnorm(12, sd = 10), x4 = rnorm(12, sd = 5))
+offsetdates <- seq(from = 2000.125,
+                   by = 0.25,
+                   length.out = 12)
+dfdata <-
+  data.frame(
+    date = seq.Date(
+      from = as.Date("2000-01-01"),
+      length.out = 12,
+      by = "quarter"
+    ),
+    x1 = rnorm(12),
+    x2 = rnorm(12),
+    x3 = rnorm(12, sd = 10),
+    x4 = rnorm(12, sd = 5)
+  )
+dfdata2 <-
+  data.frame(
+    date2 = seq.Date(
+      from = as.Date("2000-01-01"),
+      length.out = 12,
+      by = "quarter"
+    ),
+    x1 = rnorm(12),
+    x2 = rnorm(12),
+    x3 = rnorm(12, sd = 10),
+    x4 = rnorm(12, sd = 5)
+  )
 
-multidata <- handledata(NULL, list("1" = dfdata, "2" = dfdata2), NULL)$data
-expect_equal(get_x_values(multidata, x = list("1" = "date", "2" = "date2")),
-             list("1" = offsetdates, "1ts" = TRUE, "2" = offsetdates, "2ts" = TRUE))
+multidata <-
+  handledata(NULL, list("1" = dfdata, "2" = dfdata2), NULL)$data
+expect_equal(
+  get_x_values(multidata, x = list("1" = "date", "2" = "date2")),
+  list(
+    "1" = offsetdates,
+    "1ts" = TRUE,
+    "1freq" = 0.25,
+    "2" = offsetdates,
+    "2ts" = TRUE,
+    "2freq" = 0.25
+  )
+)
 
 # Same x variable across multiple datasets
 data1 <- data.frame(x1 = 1:10, x2 = rnorm(10))


### PR DESCRIPTION
Otherwise the bars were spread evenly, when they should not have.

Fixes #157 