### PR TITLE
Disable EMFplus

### DIFF
--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -187,7 +187,7 @@ startdevice <- function(filename, device, figsize) {
   } else if (device == "pdf") {
     grDevices::pdf(file = filename, width = figsize$width, height = figsize$height)
   } else if (device == "emf") {
-    devEMF::emf(file = filename, width = figsize$width, height = figsize$height)
+    devEMF::emf(file = filename, width = figsize$width, height = figsize$height, emfPlus = FALSE)
   } else if (device == "svg") {
     grDevices::svg(filename = filename, width = figsize$width, height = figsize$height)
   }


### PR DESCRIPTION
EMFplus was causing plots to look _weird_ in paint and picture viewer. Disabling EMFplus means EMFs now work in all programs!