### PR TITLE
Handle single x but multiple group bar graph

### DIFF
--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -353,7 +353,12 @@ as.barplot.x <- function(bp.data, x, xlim, bar.stacked, log_scale) {
 
     return(c(x1,x2))
   } else {
-    return(c(0,1.4))
+    if (length(bp.data) == 1) {
+      return(c(0,1.4))
+    } else {
+      bp <- graphics::barplot(t(as.matrix(bp.data)), plot = FALSE, xaxs = "i", yaxs = "i", beside = (!bar.stacked))
+      return(c(0,max(bp)+min(bp)))
+    }
   }
 }
 
@@ -372,7 +377,7 @@ drawbars <- function(l, series, bars, data, x, ists, freq, attributes, xlim, yli
   if (length(barcolumns) > 0) {
     bardata <- data[, barcolumns, drop = FALSE]
     if (!is.null(freq)) {
-      
+
       # Widen if we are missing x values (otherwise the bars are in the wrong spot (#157))
       bardata$x <- x
       equal_spaced <- data.frame(x = seq(from = min(x), to = max(x), by = freq))

--- a/tests/testthat/test-xvars.R
+++ b/tests/testthat/test-xvars.R
@@ -206,6 +206,22 @@ expect_warning({
 },
 NA)
 
+# Test for singleton without groups
+foo <- data.frame(x = 4, y = rnorm(1))
+expect_warning({
+  p <- arphitgg(foo, agg_aes(x = x, y = y)) + agg_col()
+  print(p)
+},
+NA)
+
+foo <- data.frame(x = "A", y = rnorm(1), stringsAsFactors = FALSE)
+expect_warning({
+  p <- arphitgg(foo, agg_aes(x = x, y = y)) + agg_col()
+  print(p)
+},
+NA)
+
+
 # Similar to 171 (though different cause), failure for singleton numeric x categories
 foo <- data.frame(x=1,y=rnorm(3),group=c("a","b","c"),stringsAsFactors = FALSE)
 expect_error({


### PR DESCRIPTION
The changes to fix singleton bar graphs did not work for bar graphs with single x values but with more than one group, that were not stacked. These graphs are wider (in R barplot terms) than pure singleton graphs, so the subsequent clustered bars past the first one were getting chopped off.