### PR TITLE
Add option to control label text size

### DIFF
--- a/R/annotations.R
+++ b/R/annotations.R
@@ -1,4 +1,3 @@
-
 sanitycheck.specificline <- function(line) {
   if (is.null(line$x1)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x1.")
   if (is.null(line$x2)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x2.")
@@ -84,7 +83,7 @@ drawannotationlines <- function(lines, p) {
 }
 
 drawlabel <- function(label) {
-  graphics::text(label$text, x = label$x, y = label$y, adj = c(0.5, 0.5), col = label$color)
+  graphics::text(label$text, x = label$x, y = label$y, adj = c(0.5, 0.5), col = label$color, cex = label$cex)
 }
 
 drawlabels <- function(labels, p) {

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -152,10 +152,11 @@ agg_footnote <- function(footnote) {
 #' Add a label
 #'
 #' @param text The text to display on your plot
-#' @param color The color of your text
 #' @param x The x coordinate of the center of your label
 #' @param y The y coordinate of the center of your label
 #' @param panel Which panel should the label be placed on?
+#' @param color The color of your text
+#' @param size Font size (default 20)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -164,8 +165,8 @@ agg_footnote <- function(footnote) {
 #' arphitgg(data) + agg_label("Here is a footnote", RBA["Red3"], 2003, 0.2, "1")
 #'
 #' @export
-agg_label <- function(text, color, x, y, panel) {
-  return(list(type = "label", text = text, color = color, x = x, y = y, panel = panel))
+agg_label <- function(text, x, y, panel, color = "black", size = 20) {
+  return(list(type = "label", text = text, color = color, x = x, y = y, panel = panel, cex = size / 20))
 }
 
 #' Add automatically placed label

--- a/man/agg_label.Rd
+++ b/man/agg_label.Rd
@@ -4,18 +4,20 @@
 \alias{agg_label}
 \title{Add a label}
 \usage{
-agg_label(text, color, x, y, panel)
+agg_label(text, x, y, panel, color = "black", size = 20)
 }
 \arguments{
 \item{text}{The text to display on your plot}
-
-\item{color}{The color of your text}
 
 \item{x}{The x coordinate of the center of your label}
 
 \item{y}{The y coordinate of the center of your label}
 
 \item{panel}{Which panel should the label be placed on?}
+
+\item{color}{The color of your text}
+
+\item{size}{Font size (default 20)}
 }
 \description{
 Add a label

--- a/tests/testthat/test-annotations.R
+++ b/tests/testthat/test-annotations.R
@@ -40,8 +40,6 @@ expect_equal(agg_abline(x1=2000,y1=-1,x2=2001,y2=0,panel='1'),
     lty = 1,
     type = "abline"
   ))
-
-
 nopanel <- list(list(x = 2001))
 specificerror <- list(list(
   x1 = 2000,

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -187,12 +187,35 @@ expect_equal(foo$xunits, "foo")
 expect_equal(bar$xunits, list("2" = "bar"))
 
 # Labels
-foo <- arphitgg(data) + agg_label("Text", "red", 2002, 0.2, "1")
-bar <- arphitgg(data) + agg_label("Text", "red", 2002, 0.2, "1") + agg_label("Second label", "green", 2003, -0.2, "1")
+foo <- arphitgg(data) + agg_label("Text", 2002, 0.2, "1", "red")
+bar <- arphitgg(data) + agg_label("Text", 2002, 0.2, "1", "red") + agg_label("Second label",2003, -0.2, "1", "green", 40)
 
-expect_equal(foo$labels, list(list(text = "Text", color = "red", x = 2002, y = 0.2, panel = "1")))
-expect_equal(bar$labels, list(list(text = "Text", color = "red", x = 2002, y = 0.2, panel = "1"),
-                              list(text = "Second label", color = "green", x = 2003, y = -0.2, panel = "1")))
+expect_equal(foo$labels, list(list(
+  text = "Text",
+  color = "red",
+  x = 2002,
+  y = 0.2,
+  panel = "1",
+  cex=1
+)))
+expect_equal(bar$labels, list(
+  list(
+    text = "Text",
+    color = "red",
+    x = 2002,
+    y = 0.2,
+    panel = "1",
+    cex = 1
+  ),
+  list(
+    text = "Second label",
+    color = "green",
+    x = 2003,
+    y = -0.2,
+    panel = "1",
+    cex = 2
+  )
+))
 
 # Arrows
 foo <- arphitgg(data) + agg_arrow(2000, 0, 2001, 2, "red", "1")


### PR DESCRIPTION
Add size argument to `agg_label`, which converts to `cex` internally.

Closes #188 