### PR TITLE
Fix incorrect text masking with LHS/RHS axes in autolabeller

### DIFF
--- a/R/autolabel-collision.R
+++ b/R/autolabel-collision.R
@@ -45,7 +45,7 @@ create_text_bitmap <- function(x,y,text,xlim,ylim,dim,layout,p,padding = AUTOLAB
   x_start <- seq(from = xlim[1], to = xlim[2], length.out = round(dim[1]/x_scale) + 1)[1:round(dim[1]/x_scale)]
   y_start <- seq(from = ylim$max, to = ylim$min, length.out = round(dim[2]/y_scale) + 1)[2:(round(dim[2]/y_scale)+1)]
 
-  left <- x - 0.5*(getstrwidth(text, units = "inches") - padding) / (graphics::par("pin")[1])*(xlim[2]-xlim[1])
+  left <- x - 0.5*(getstrwidth(text, units = "inches") + padding) / (graphics::par("pin")[1])*(xlim[2]-xlim[1])
   right <- x + 0.5*(getstrwidth(text, units = "inches") + padding) / (graphics::par("pin")[1])*(xlim[2]-xlim[1])
   x_indices <- which(x_start < right & (x_start + x_start[2]-x_start[1]) > left)
 
@@ -81,6 +81,6 @@ shift_text_indices <- function(indices,x,y,x_text_anchor,y_text_anchor,x_scale,y
 }
 
 test_collision <- function(underlay, x_indices, y_indices, dim) {
-  any(x_indices < 0 | x_indices > dim[1] | y_indices < 0 | y_indices > dim[2]) ||
-  any(underlay[x_indices, y_indices])
+  any(x_indices < 0) || any(x_indices > dim[1]) || any(y_indices < 0) ||
+    any(y_indices > dim[2]) || any(underlay[x_indices, y_indices])
 }

--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -1,7 +1,9 @@
 evaluate_candidate <- function(x, y, text_indices, x_text_anchor, y_text_anchor, x_scale, y_scale, series, otherseries, series_types, data, xvals, yvals, xlim, ylim, layout, p, underlay_bitmap, los_mask, bars, bars.stacked, inches_conversion) {
 
-  indices <- shift_text_indices(text_indices,x,y,x_text_anchor,y_text_anchor,x_scale,y_scale,xlim,ylim,dim(underlay_bitmap),layout,p)
-  if (!test_collision(underlay_bitmap, indices$x, indices$y)) {
+  dim <- dim(underlay_bitmap)
+
+  indices <- shift_text_indices(text_indices,x,y,x_text_anchor,y_text_anchor,x_scale,y_scale,xlim,ylim,dim,layout,p)
+  if (!test_collision(underlay_bitmap, indices$x, indices$y, dim)) {
     distance <- get_distance(x, y, data, xvals, yvals, series, otherseries, series_types, bars, bars.stacked, los_mask, xlim, ylim, inches_conversion)
 
     distance$x <- x

--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -111,11 +111,12 @@ autolabel_fallback <- function(label, xlim, ylim, underlay_bitmap, layout, p, qu
   x_steps <- c(rbind(x_up,x_down))
   y_steps <- c(rbind(y_up,y_down))
 
+  dim <- dim(underlay_bitmap)
   for (x in x_steps) {
     if (!quiet) cat("x")
     for (y in y_steps) {
-      indices <- create_text_bitmap(x,y,label,xlim,ylim,dim(underlay_bitmap),layout,p,padding=AUTOLABEL_FALLBACK_PADDING)
-      if (!test_collision(underlay_bitmap, indices$x, indices$y)) {
+      indices <- create_text_bitmap(x,y,label,xlim,ylim,dim,layout,p,padding=AUTOLABEL_FALLBACK_PADDING)
+      if (!test_collision(underlay_bitmap, indices$x, indices$y, dim)) {
         return(data.frame(x=x,y=y,distance=0,los=TRUE,next_closest=Inf))
       }
     }


### PR DESCRIPTION
Closes #199 and #198 