### PR TITLE
Remove single series panels from autolabel list

### DIFF
--- a/R/autolabel-utils.R
+++ b/R/autolabel-utils.R
@@ -12,6 +12,13 @@ createlabels <- function(panels, bars, attributes, layout, labels) {
     }
   }
 
+  # Remove any single-panel series if that panel has only one series (doesn't need a label!)
+  for (series in names(series_to_panels)) {
+    if (length(series_to_panels[[series]]) == 1 && length(panels[[series_to_panels[[series]]]]) == 1) {
+      series_to_panels[series] <- NULL
+    }
+  }
+
   # if is a RHS axes, add annotations
   series_to_labels <- list()
   for (series in names(series_to_panels)) {

--- a/R/autolabel-utils.R
+++ b/R/autolabel-utils.R
@@ -15,7 +15,15 @@ createlabels <- function(panels, bars, attributes, layout, labels) {
   # Remove any single-panel series if that panel has only one series (doesn't need a label!)
   for (series in names(series_to_panels)) {
     if (length(series_to_panels[[series]]) == 1 && length(panels[[series_to_panels[[series]]]]) == 1) {
-      series_to_panels[series] <- NULL
+      # check there aren't series on alternative axes
+      other_p <- other_axes(series_to_panels[[series]], layout)
+      if (!is.null(other_p)) {
+        if(!length(panels[[other_p]]) > 0) {
+          series_to_panels[series] <- NULL
+        }
+      } else {
+        series_to_panels[series] <- NULL
+      }
     }
   }
 

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -187,3 +187,26 @@ p <- arphitgg(data,agg_aes(x=x), layout = "2v") +
 expect_error({print(p)}, NA)
 
 graphics.off()
+
+# Bug where labels were being added to single series panels incorrectly (#201)
+expect_equal(length(createlabels(
+  list("1" = "a"), c(), list("1" = list(
+    col = list(a = "red"), pch = list(a = 1)
+  )), '1', list()
+)$series_to_panels),
+0)
+
+# And now where have labels on one panel but not the other
+expect_equal(
+  names(createlabels(
+    list("1" = c("a", "b"), "2" = "c"),
+    c(),
+    list(
+      "1" = list(col = list(a = "red", b = "green"), pch = list(a = 1, b = 1)),
+      "2" = list(col = list(c = "red"), pch =
+                   list(c = 1))
+    ),
+    '2v',
+    list()
+  )$series_to_labels),
+  c("a","b"))


### PR DESCRIPTION
Previously was adding these to the list needing labels, meaning panels with only one series were also labelled. Closes #201