### PR TITLE
Handle missing observations in bar graphs

### DIFF
--- a/R/autolabel-distance.R
+++ b/R/autolabel-distance.R
@@ -55,6 +55,7 @@ point_bar_distance <- function(x, y, series.x, series.y, data, bars, bars.stacke
       return(point_bar_distance_(x, y, series.x, rep(0, length(series.y)), series.y, inches_conversion))
     } else {
       bardata <- bardata[1:row_n,]
+      bardata[is.na(bardata)] <- 0
       bardata_p <- bardata
       bardata_n <- bardata
       bardata_p[bardata <= 0] <- 0

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -228,3 +228,13 @@ p <- arphitgg(data) +
   agg_xlim(2011,2013) +
   agg_autolabel()
 expect_error(print(p), NA)
+
+# Missing observations in stacked bar graphs (#217)
+
+data <- data.frame(series_name = letters[1:10], value = rnorm(10), group = sample(1:3,10,TRUE))
+expect_error({
+  p <-
+    arphitgg(data, agg_aes(x = series_name, y = value, group = group)) +
+    agg_col() + agg_autolabel()
+  print(p)
+}, NA)


### PR DESCRIPTION
Previously was causing havoc in how location of stacked bars are determined.

Closes #217 