### PR TITLE
Improve how the frequency of dates is determined

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,5 +12,6 @@
 ## Bugfixes
 
  * Automatically guessed y-limits are now based only on visible data (e.g. they now respect x-limits) ([#213](https://github.com/angusmoore/arphit/pull/213))
+ * Corrected handling of higher frequency data (e.g. weekly, hourly) and semi-annual data ([#221](https://github.com/angusmoore/arphit/pull/221))
 
 ## Deprecated or removed

--- a/R/xvars.R
+++ b/R/xvars.R
@@ -1,22 +1,16 @@
 frequencyof <- function(dates) {
-  dates <- lubridate::decimal_date(dates)
-  if (length(dates) > 1) {
-    smallestdiff <- min(abs(diff(dates))[abs(diff(dates)) > 0])
-    options <- c(1, 1/4, 1/12, 1/(365/7), 1/365)
-    bestchoice <- abs(log(smallestdiff) -log(options)) < 0.1
-    if (sum(bestchoice) == 1) {
-      return(options[bestchoice])
-    } else {
-      if (smallestdiff > 1) {
-        # If frequency is more than a year, just use years
-        return(1)
-      } else {
-        return(NULL)
-      }
+  # Remove duplicate dates first
+  dates <- unique(dates)
+  for (frequency in c(1, 1/2, 1/4, 1/12, 1/(365/7), 1/365)) {
+    if (!any(duplicated(make_decimal_date(dates, frequency)))) {
+      return(frequency)
     }
-  } else {
-    return(1)
   }
+  return(NULL)
+}
+
+days_in_year <- function(date) {
+  unname(lubridate::days_in_month(lubridate::make_date(lubridate::year(date), 2, 1))) + 337
 }
 
 make_decimal_date <- function(date, frequency) {
@@ -24,6 +18,8 @@ make_decimal_date <- function(date, frequency) {
     return(lubridate::decimal_date(date))
   } else if (frequency == 1) {
     return(lubridate::year(date) + 0.5)
+  } else if (frequency == 1/2) {
+    return(lubridate::year(date) + (lubridate::semester(date) - 0.5)/2)
   } else if (frequency == 1/4) {
     return(lubridate::year(date) + (lubridate::quarter(date) - 0.5)/4)
   } else if (frequency == 1/12) {
@@ -31,7 +27,7 @@ make_decimal_date <- function(date, frequency) {
   } else if (frequency == 1/(365/7)) {
     return(lubridate::year(date) + (lubridate::week(date) - 0.5)/(365/7))
   } else if (frequency == 1/365) {
-    return(lubridate::decimal_date(date) + 0.5/365)
+    return(lubridate::year(date) + (lubridate::yday(date) - 0.5)/days_in_year(date))
   }
   stop("Unknown frequency")
 }

--- a/R/xvars.R
+++ b/R/xvars.R
@@ -39,7 +39,7 @@ get_x_values <- function(data, x) {
       if (x[[p]] %in% names(data[[p]])) {
         outx[[p]] <- data[[p]][[x[[p]]]]
         # if is dates, convert to year fractions
-        if (lubridate::is.Date(outx[[p]])) {
+        if (lubridate::is.Date(outx[[p]]) || lubridate::is.POSIXt(outx[[p]])) {
           freq <- frequencyof(outx[[p]])
           outx[[p]] <- make_decimal_date(outx[[p]], freq)
           # Add a little helper to tell other functions we have time series data

--- a/tests/testthat/test-xvars.R
+++ b/tests/testthat/test-xvars.R
@@ -108,6 +108,11 @@ expect_equal(frequencyof(years), 1)
 # Bad behaviour with non recognised frequencies of data
 expect_equal(frequencyof(seq.Date(from=as.Date("2000-01-01"),by="week",length.out = 100)), 1/(365/7))
 expect_null(frequencyof(seq.POSIXt(from=ISOdate(1999,1,1),by="hour",length.out = 100)))
+# duplicate dates
+duplicate_dates <- as.Date(c("2000-03-01","2000-06-01","2000-09-01","2000-09-01","2000-12-01","2001-03-01"))
+expect_equal(frequencyof(duplicate_dates), 1/4)
+# single date
+expect_equal(frequencyof(as.Date("2018-06-01")), 1)
 
 # weekly data
 data <-
@@ -165,6 +170,14 @@ expect_error(
   print(p),
   NA
 )
+
+foo <- data.frame(x = seq(from = as.Date("2000-01-01"),length.out=1000,by="day"),y=rnorm(1000))
+p <- arphitgg(foo, agg_aes(x=x,y=y))+agg_line()
+expect_error(
+  print(p),
+  NA
+)
+
 
 # Test #37
 # Error if x variable has NA values

--- a/tests/testthat/test-xvars.R
+++ b/tests/testthat/test-xvars.R
@@ -136,6 +136,16 @@ expect_error({
   print(p)
 }, NA)
 
+# hourly data
+data <-
+  data.frame(date = seq.POSIXt(from=ISOdate(1999,1,1),by="hour",length.out = 100),
+  y = rnorm(100))
+expect_error({
+  p <- arphitgg(data, agg_aes(x = date, y = y)) + agg_line()
+  print(p)
+}, NA)
+
+
 
 # Test old bug from old frequency guessing causing incorrect labels with irregularly spaced data
 data <- data.frame(year = c(1991, 2001, 2006, 2011, 2016), y = rnorm(5))


### PR DESCRIPTION
Closes #197 
Now we guess frequency by cycling from largest to smallest frequency options until collapsing to that frequency does not generate duplicate dates.

Treat POSIX as time series too