### PR TITLE
Better handling of x-ticks for non-integer x-limits

### DIFF
--- a/R/axes.R
+++ b/R/axes.R
@@ -223,10 +223,15 @@ findlabelstep <- function(start, end, layout_factor, exponent = 1) {
   return(findlabelstep(start, end, layout_factor, exponent*10))
 }
 
-restrictlabels <- function(ticks, layout_factor) {
+restrictlabels <- function(ticks, layout_factor, partial_end_year = FALSE) {
   step <- findlabelstep(1, length(ticks), layout_factor)
   n <- floor((length(ticks) - 1) / step) + 1
-  return(seq(to = length(ticks), length.out = n, by = step))
+  if (!partial_end_year) {
+    to <- length(ticks)
+  } else {
+    to <- length(ticks) - 1
+  }
+  return(seq(to = , length.out = n, by = step))
 }
 
 getlayoutfactor <- function(layout) {
@@ -241,14 +246,16 @@ getlayoutfactor <- function(layout) {
 
 xlabels.ts <- function(xlim, layout) {
   layout_factor <- getlayoutfactor(layout)
-  startyear <- xlim[1]
-  endyear <- xlim[2]
+  startyear <- floor(xlim[1])
+  endyear <- ceiling(xlim[2])
   # Create the sequence and offset the labels by half a year so that the labels are centered
   ticks <- seq(from = startyear, to = (endyear-1), by = 1)
-  keep <- restrictlabels(ticks, layout_factor)
+  keep <- restrictlabels(ticks, layout_factor, xlim[2] < endyear) # Only keep every 3rd or whatever label
   labels <- ticks[keep]
   at <- labels + 0.5
-  return(list("at" = at, "labels" = labels, "ticks" = ticks))
+  # drop any labels that are outside the x limits
+  keep <- at >= xlim[1] & at <= xlim[2]
+  return(list(at = at[keep], labels = labels[keep], ticks = ticks))
 }
 
 xlabels.categorical <- function(xlim, xvar, layout, showall) {

--- a/R/axes.R
+++ b/R/axes.R
@@ -231,7 +231,7 @@ restrictlabels <- function(ticks, layout_factor, partial_end_year = FALSE) {
   } else {
     to <- length(ticks) - 1
   }
-  return(seq(to = , length.out = n, by = step))
+  return(seq(to = to, length.out = n, by = step))
 }
 
 getlayoutfactor <- function(layout) {
@@ -250,7 +250,7 @@ xlabels.ts <- function(xlim, layout) {
   endyear <- ceiling(xlim[2])
   # Create the sequence and offset the labels by half a year so that the labels are centered
   ticks <- seq(from = startyear, to = (endyear-1), by = 1)
-  keep <- restrictlabels(ticks, layout_factor, xlim[2] < endyear) # Only keep every 3rd or whatever label
+  keep <- restrictlabels(ticks, layout_factor, xlim[2] < endyear && xlim[2] - xlim[1] > 3) # Only keep every 3rd or whatever label
   labels <- ticks[keep]
   at <- labels + 0.5
   # drop any labels that are outside the x limits

--- a/tests/testthat/test-axes.R
+++ b/tests/testthat/test-axes.R
@@ -559,3 +559,14 @@ expect_error({
     arphitgg(data, agg_aes(x = x, y = y)) + agg_line() + agg_xlim(NA, 2005)
   print(p)
 }, NA)
+
+# Poor handling of x labels for non-integer x limits in time series
+expect_equal(xlabels.ts(c(2008.008,2009.008), "1")$at %% 1, 0.5)
+expect_true(all((xlabels.ts(c(2008.008,2019.008), "1")$at %% 1) ==0.5))
+
+# Showing labels waaay off of panels for high frequency data
+for (i in 1:1000) {
+  x <- runif(1)
+  expect_lte(xlabels.ts(c(2008 + x, 2009 + x), "1")$at, 2009 + x)
+  expect_gte(xlabels.ts(c(2008 + x, 2009 + x), "1")$at, 2008 + x)
+}


### PR DESCRIPTION
The old `xlabels.ts` assumed x limits would be integer years. This is a bad assumption - it may not be true for high frequency graphs.

This PR improves handling of that and, as a bonus, also correctly handles partial last years by putting the label on the last _full_ year.