### PR TITLE
Use Arial instead of sans for non-windows systems

### DIFF
--- a/R/autolabel-line-of-sight.R
+++ b/R/autolabel-line-of-sight.R
@@ -94,7 +94,7 @@ create_los_mask <- function(series, panels, p, data, xvals, dims, xlim, ylim, ba
     height = dims[2] / graphics::par("mfrow")[1],
     res = PNGDPI
   )
-  graphics::par(family = "sans", xaxs = "i", yaxs = "i", ps = 20, cex.main = (28/20), cex.axis = 1, las = 1, lheight = 1)
+  graphics::par(family = font_family(), xaxs = "i", yaxs = "i", ps = 20, cex.main = (28/20), cex.axis = 1, las = 1, lheight = 1)
   graphics::par(omi = c(0,0,0,0), mar = c(0,0,0,0))
   graphics::plot(0, lwd = 0, pch = NA, axes = FALSE, xlab = "", ylab = "",
                  xlim = c(0,1), ylim = c(0, 1))

--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -1,8 +1,8 @@
 font_family <- function() {
-  if(capabilities()[["X11"]]) {
-    return("Arial")
-  } else {
+  if(.Platform$OS.type == "windows") {
     return("sans")
+  } else {
+    return("Arial")
   }
 }
 

--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -1,3 +1,11 @@
+font_family <- function() {
+  if(capabilities()[["X11"]]) {
+    return("Arial")
+  } else {
+    return("sans")
+  }
+}
+
 finddevice <- function(filename) {
   if (is.null(filename)) {
     return(NULL)
@@ -204,6 +212,6 @@ createfigure <- function(filename, device, figsize, plotsize) {
   graphics::par(pin = plotsize, plt = plotcorners)
 
   # Misc display things
-  graphics::par(family = "sans", xaxs = "i", yaxs = "i", ps = 20, cex.main = (28/20), cex.axis = 1, las = 1, lheight = 1)
+  graphics::par(family = font_family(), xaxs = "i", yaxs = "i", ps = 20, cex.main = (28/20), cex.axis = 1, las = 1, lheight = 1)
   graphics::par(omi = c(figsize$bottom, figsize$left, figsize$top, figsize$right))
 }

--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -1,5 +1,7 @@
 font_family <- function() {
-  if(.Platform$OS.type == "windows") {
+  if (names(dev.cur()) == "pdf") {
+    return("ArialMT")
+  } else if(.Platform$OS.type == "windows") {
     return("sans")
   } else {
     return("Arial")

--- a/R/notes.R
+++ b/R/notes.R
@@ -54,7 +54,7 @@ formatfn <- function(footnotes, width) {
 
 splitoverlines <- function(s, maxsize, cex) {
   # Set values needed to determine str widths
-  graphics::par(family = "sans", xaxs = "i", yaxs = "i", ps = 20, las = 1, lheight = 1)
+  graphics::par(family = font_family(), xaxs = "i", yaxs = "i", ps = 20, las = 1, lheight = 1)
 
   breakpoints <- c()
   if (nchar(s) > 0) {


### PR DESCRIPTION
According to [documentation ](https://stat.ethz.ch/R-manual/R-devel/library/grDevices/html/png.html) for `png` 

> The default font family is Arial on Windows and Helvetica otherwise.

Specify Arial as the font on non-windows systems. Arial is not a recognised `windowsFont` (which is why we use `sans`, but is a recognised `X11Font`.