### PR TITLE
Use PDFs instead of PNG in autolabeller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ r_github_packages:
 before_install:
   - chmod 755 ./.push_gh_pages.sh
   - sudo apt-get update
-  - sudo apt-get install -y libmagick++-dev
+  - sudo apt-get install -y libmagick++-dev libpoppler-cpp-dev
 
 after_success:
   - Rscript -e 'covr::coveralls()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
   devEMF,
   zoo,
   xts,
+  pdftools,
   magick
 Suggests:
   testthat,

--- a/R/autolabel-collision.R
+++ b/R/autolabel-collision.R
@@ -2,7 +2,7 @@ get_underlay_bitmap <- function(gg, margins) {
   plot_device <- grDevices::dev.cur()
   gg$enable_autolabeller <- FALSE
   agg_draw(gg, filename = paste0(tempdir(), "/autolabel-temp.pdf"))
-  image <- magick::image_read(paste0(tempdir(), "/autolabel-temp.pdf"))
+  image <- magick::image_read_pdf(paste0(tempdir(), "/autolabel-temp.pdf"))
   suppressWarnings(file.remove(paste0(tempdir(), "/autolabel-temp.pdf")))
 
   # Crop off the outer material

--- a/R/autolabel-collision.R
+++ b/R/autolabel-collision.R
@@ -1,9 +1,9 @@
 get_underlay_bitmap <- function(gg, margins) {
   plot_device <- grDevices::dev.cur()
   gg$enable_autolabeller <- FALSE
-  agg_draw(gg, filename = paste0(tempdir(), "/autolabel-temp.png"))
-  image <- magick::image_read(paste0(tempdir(), "/autolabel-temp.png"))
-  suppressWarnings(file.remove(paste0(tempdir(), "/autolabel-temp.png")))
+  agg_draw(gg, filename = paste0(tempdir(), "/autolabel-temp.pdf"))
+  image <- magick::image_read(paste0(tempdir(), "/autolabel-temp.pdf"))
+  suppressWarnings(file.remove(paste0(tempdir(), "/autolabel-temp.pdf")))
 
   # Crop off the outer material
   top <- as.integer(CSI*margins$top*PNGDPI)


### PR DESCRIPTION
It's slightly slower, but it ensures autolabel masks are platform independent.