### PR TITLE
Remove paneltitles from qplot

### DIFF
--- a/R/qplot.R
+++ b/R/qplot.R
@@ -113,8 +113,6 @@ handlebars <- function(data, bars) {
 #' @param filename (optional) If specified, save image to filename instead of displaying in R. Supports pdf, emf and png extensions.
 #' @param title (optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.
 #' @param subtitle (optional) A string indicating the subtitle for the entire chart. Passing NULL (or omitting the argument) will suppress printing of subtitle.
-#' @param paneltitles (optional) A list of string -> string pairs indicating panel titles. Keys must be "1", "2", etc to indicate which panel the title is for.
-#' @param panelsubtitles (optional) A list string -> string pairs indicating panel titles. See paneltitles.
 #' @param footnotes (optional) A vector strings, corresponding to the footnotes, in order.
 #' @param sources (optional) A vector of strings, one entry for each source.
 #' @param yunits (optional) A list of string -> string pairs indicating the units to be used on each panel (/axes, see notes to series for explanation on how right-hand-side axes are treated). Alternatively, providing just a string will assign that to all panels. If not supplied, a per cent sign will be used.
@@ -140,15 +138,11 @@ handlebars <- function(data, bars) {
 #'   footnotes = c("a","B"), sources = c("A Source", "Another source"), yunits = "index")
 #'
 #' @export
-agg_qplot <- function(data, series = NULL, x = NULL, layout = "1", bars = NULL, filename = NULL, title = NULL, subtitle = NULL, paneltitles = list(), panelsubtitles = list(), footnotes = c(), sources = c(), yunits = NULL, col = list(), pch = list(), lty = list(), lwd = list(), xlim = list(), ylim = list(), legend = FALSE, legend.ncol = NA, bar.stacked = TRUE) {
+agg_qplot <- function(data, series = NULL, x = NULL, layout = "1", bars = NULL, filename = NULL, title = NULL, subtitle = NULL, footnotes = c(), sources = c(), yunits = NULL, col = list(), pch = list(), lty = list(), lwd = list(), xlim = list(), ylim = list(), legend = FALSE, legend.ncol = NA, bar.stacked = TRUE) {
 
   data <- conformdata(data, layout, series)
   x <- conformxvariable(x, data, layout)
   bars <- handlebars(data, bars)
-
-  if (!is.list(paneltitles)) {
-    stop("`paneltitles` must be a list.")
-  }
 
   agg_draw_internal(
     list(
@@ -158,8 +152,8 @@ agg_qplot <- function(data, series = NULL, x = NULL, layout = "1", bars = NULL, 
       bars = bars,
       title = title,
       subtitle = subtitle,
-      paneltitles = paneltitles,
-      panelsubtitles = panelsubtitles,
+      paneltitles = list(),
+      panelsubtitles = list(),
       yaxislabels = list(),
       xaxislabels = list(),
       footnotes = footnotes,

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -5,8 +5,7 @@
 \title{RBA-style graphs in R}
 \usage{
 agg_qplot(data, series = NULL, x = NULL, layout = "1", bars = NULL,
-  filename = NULL, title = NULL, subtitle = NULL,
-  paneltitles = list(), panelsubtitles = list(), footnotes = c(),
+  filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
   sources = c(), yunits = NULL, col = list(), pch = list(),
   lty = list(), lwd = list(), xlim = list(), ylim = list(),
   legend = FALSE, legend.ncol = NA, bar.stacked = TRUE)
@@ -30,10 +29,6 @@ Alternatively if just a vector of string names is supplied, it will be assumed a
 \item{title}{(optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.}
 
 \item{subtitle}{(optional) A string indicating the subtitle for the entire chart. Passing NULL (or omitting the argument) will suppress printing of subtitle.}
-
-\item{paneltitles}{(optional) A list of string -> string pairs indicating panel titles. Keys must be "1", "2", etc to indicate which panel the title is for.}
-
-\item{panelsubtitles}{(optional) A list string -> string pairs indicating panel titles. See paneltitles.}
 
 \item{footnotes}{(optional) A vector strings, corresponding to the footnotes, in order.}
 

--- a/tests/testthat/test-qplot.R
+++ b/tests/testthat/test-qplot.R
@@ -19,12 +19,3 @@ test_that("Errors for wrong x vars", {
                fixed = TRUE)
 })
 
-test_that("Errors for paneltitles", {
-  data <- data.frame(x=1:10,y=rnorm(10))
-  expect_error(agg_qplot(data, x="x", paneltitles = "foo"),
-               "`paneltitles` must be a list.")
-
-  skip("This should throw an error but is not")
-  expect_error(agg_qplot(data, x="x", panelsubtitles = "foo"),
-               "`paneltitles` must be a list.")
-})

--- a/vignettes/qplot-options.Rmd
+++ b/vignettes/qplot-options.Rmd
@@ -382,23 +382,6 @@ agg_qplot(data, title = "Here is a very very very long title that arphit will au
 knitr::include_graphics("longtitle.png")
 ```
 
-# Panel titles and subtitles
-
-You can add titles and subtitles to panels using the `paneltitle` and `panelsubtitle` arguments. These are lists of panel identifiers (e.g. "1") to strings. For example:
-```{r, eval = FALSE}
-agg_qplot(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), paneltitle = list("1" = "Panel 1", "2" = "Panel 2", "3" = "Panel 3", "4" = "Panel 4"))
-```
-```{r, echo = FALSE, results = "hide"}
-agg_qplot(data, layout = "2b2", series = list("1" = c("x1"), "2" = c("x2"), "3" = c("x3"), "4" = c("x4")), paneltitle = list("1" = "Panel 1", "2" = "Panel 2", "3" = "Panel 3", "4" = "Panel 4"), filename = "paneltitle.png")
-```
-```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("paneltitle.png")
-```
-
-And likewise for panelsubtitle.
-
-`arphit` will attempt to insert line breaks as necessary, but may not be smart enough in all cases. You can insert linebreaks yourself as necessary by using "\\n".
-
 # Footnotes and sources
 
 ## Footnotes


### PR DESCRIPTION
Only have one panel layouts, so no need. Closes #238 