### PR TITLE
Convert qplot to just a wrapper over the public gg interface

### DIFF
--- a/R/qplot.R
+++ b/R/qplot.R
@@ -18,9 +18,19 @@ check_attribute_series_names <- function(attr, series_names) {
   }
 }
 
-#' RBA-style graphs in R
-#'
-#' Quickly creates a (potentially multipanel) graph. Supports bar and line (and combinations of).
+qplot_get_attribute <- function(att, y) {
+  if (!is.null(att)) {
+    if (!is.list(att)) {
+      return(att)
+    } else {
+      return(att[[y]])
+    }
+  } else {
+    return(NULL)
+  }
+}
+
+#' Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).
 #'
 #' @param data Object containing the series you want to plot. Can be a `data.frame`,
 #' `tibble`, `zoo`, `xts` or `ts`.
@@ -110,9 +120,13 @@ agg_qplot <- function(data, series = NULL, x = NULL, bars = FALSE, filename = NU
   for (y in series) {
     aes <- list(type = "aes", x = x, y = y, group = NULL, facet = NULL, order = x)
     if ((is.logical(bars) && bars) || (y %in% bars)) {
-      p <- p + agg_col(aes = aes, col = col[[y]])
+      p <- p + agg_col(aes = aes, color = qplot_get_attribute(col, y))
     } else {
-      p <- p + agg_line(aes = aes, col = col[[y]], pch = pch[[y]], lty = pch[[y]], lwd = lwd[[y]])
+      p <- p + agg_line(aes = aes,
+                        color = qplot_get_attribute(col, y),
+                        pch = qplot_get_attribute(pch, y),
+                        lty = qplot_get_attribute(pch, y),
+                        lwd = qplot_get_attribute(lwd, y))
     }
   }
 

--- a/R/qplot.R
+++ b/R/qplot.R
@@ -50,7 +50,7 @@ qplot_get_attribute <- function(att, y) {
 #' @param footnotes (optional) A vector strings, corresponding to the footnotes, in order.
 #' @param sources (optional) A vector of strings, one entry for each source.
 #' @param yunits (optional) A string indicating the units to be used. If not
-#' supplied, a % sign will be used.
+#' supplied, a \% sign will be used.
 #' @param col (optional) A list of string -> misc pairs. The keys should be
 #' series names, and the values colours for each series (any colour accepted by
 #' R is fine.) You need not supply colours for all series. Default colours will

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/qplot.R
 \name{agg_qplot}
 \alias{agg_qplot}
-\title{Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).}
+\title{RBA-style graphs in R}
 \usage{
 agg_qplot(data, series = NULL, x = NULL, bars = NULL,
   filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
@@ -51,7 +51,7 @@ you want to plot.}
 \item{bar.stacked}{(optional) Logical indicating whether the bar series should be stacked (TRUE, default) or side-by-side (FALSE).}
 }
 \description{
-Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).
+Quickly creates a (potentially multipanel) graph. Supports bar and line (and combinations of).
 }
 \examples{
 T <- 24

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -4,69 +4,51 @@
 \alias{agg_qplot}
 \title{Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).}
 \usage{
-agg_qplot(data, series = NULL, x = NULL, bars = FALSE,
+agg_qplot(data, series = NULL, x = NULL, bars = NULL,
   filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
   sources = c(), yunits = NULL, col = list(), pch = list(),
-  lty = list(), lwd = list(), xlim = NULL, ylim = NULL,
+  lty = list(), lwd = list(), xlim = list(), ylim = list(),
   legend = FALSE, legend.ncol = NA, bar.stacked = TRUE)
 }
 \arguments{
-\item{data}{Object containing the series you want to plot. Can be a `data.frame`,
-`tibble`, `zoo`, `xts` or `ts`.}
+\item{data}{Object containing the series you want to plot. Can be a data.frame, tibble or ts. Can also be a list of the above, with separate for each panel.}
 
 \item{series}{A vector of series names specifying which subset of series
 you want to plot.}
 
-\item{x}{The x variable for your plot. Not required for `ts`, `xts` and `zoo`
-data because they use the dates in the time series.}
+\item{x}{The x variable for your plot. `ts`, `xts` and `zoo` data use the dates in the time series.}
 
-\item{bars}{(optional) Vector of string names indicating which series should
-be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series
-will plot as bars.}
+\item{bars}{(optional) Vector of string names indicating which series should be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series will plot as bars.}
 
-\item{filename}{(optional) If specified, save image to filename instead of
-displaying in R. Supports svg, pdf, emf, emf+ and png extensions.}
+\item{filename}{(optional) If specified, save image to filename instead of displaying in R. Supports pdf, emf and png extensions.}
 
-\item{title}{(optional) A string indicating the title for the graph. Passing
-`NULL` (or omitting the argument) will suppress printing of title.}
+\item{title}{(optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.}
 
-\item{subtitle}{(optional) A string indicating the subtitle for the graph.
-Passing `NULL` (or omitting the argument) will suppress printing of subtitle.}
+\item{subtitle}{(optional) A string indicating the subtitle for the entire chart. Passing NULL (or omitting the argument) will suppress printing of subtitle.}
 
 \item{footnotes}{(optional) A vector strings, corresponding to the footnotes, in order.}
 
 \item{sources}{(optional) A vector of strings, one entry for each source.}
 
-\item{yunits}{(optional) A string indicating the units to be used. If not
-supplied, a % sign will be used.}
+\item{yunits}{(optional) A list of string -> string pairs indicating the units to be used on each panel (/axes, see notes to series for explanation on how right-hand-side axes are treated). Alternatively, providing just a string will assign that to all panels. If not supplied, a per cent sign will be used.}
 
-\item{col}{(optional) A list of string -> misc pairs. The keys should be
-series names, and the values colours for each series (any colour accepted by
-R is fine.) You need not supply colours for all series. Default colours will
-be assigned  (cycling through) to series without assigned colours.
-Alternatively, you can supply a single value to apply to all series.}
+\item{col}{(optional) A list of string -> misc pairs. The keys should be series names, and the values colours for each series (any colour accepted by R is fine.) You need not supply colours for all series. Default colours will be assigned  (cycling through) to series without assigned colours. Alternatively, you can supply a single value to apply to all series.}
 
-\item{pch}{(optional) Markers for your series. Passed as with `col`.
-Defaults to none (NA).}
+\item{pch}{(optional) A list of string -> int pairs. The keys should be series names, and the values markers (pch values) for each series. Defaults to none (NA). Can be supplied as list, or a single value (which will be applied to all series).}
 
-\item{lty}{(optional) Line types for each series.  Passed as with `col`.
-Defaults to solid (1).}
+\item{lty}{(optional) A list of string -> int pairs. The keys should be series names, and the values line types (lty values) for each series. Defaults to solid (1). Can be supplied as list, or a single value (which will be applied to all series).}
 
-\item{lwd}{(optional) Line width, relative to default, for each series.
-Passed as with `col`.}
+\item{lwd}{(optional) A list of string -> numeric pairs. The keys should be series names, and the values line width, relative to default, for each series. Defaults to 1. Can be supplied as list, or a single value (which will be applied to all series).}
 
-\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph.}
+\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph. Alternatively, you can supply a list to provide different x limits for each panel (not recommended). If unsupplied, a suitable default is chosen (recommended).}
 
-\item{ylim}{(optional) A list(min = numeric, max = numeric, nsteps int).
-If unsupplied, a suitable default is chosen.}
+\item{ylim}{(optional) A list of string -> list(min = numeric, max = numeric, nsteps int) pairs. Keys are panel names (e.g. "1", "2", etc). Values are the scale, provided as a list with the keys min, max and nsteps. If unsupplied, a suitable default is chosen (recommended, but will not work well for multipanels).}
 
 \item{legend}{A logical indicating whether to add a legend to the graph (default FALSE).}
 
-\item{legend.ncol}{(optional) How many columns do you want the legend to have (if NA,
-which is the default, arphit will guess for you).}
+\item{legend.ncol}{How many columns do you want the legend to have (if NA, which is the default, arphit will guess for you).}
 
-\item{bar.stacked}{(optional) Logical indicating whether the bar series should
-be stacked (TRUE, default) or side-by-side (FALSE).}
+\item{bar.stacked}{(optional) Logical indicating whether the bar series should be stacked (TRUE, default) or side-by-side (FALSE).}
 }
 \description{
 Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/qplot.R
 \name{agg_qplot}
 \alias{agg_qplot}
-\title{RBA-style graphs in R}
+\title{Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).}
 \usage{
 agg_qplot(data, series = NULL, x = NULL, bars = FALSE,
   filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
@@ -69,7 +69,7 @@ which is the default, arphit will guess for you).}
 be stacked (TRUE, default) or side-by-side (FALSE).}
 }
 \description{
-Quickly creates a (potentially multipanel) graph. Supports bar and line (and combinations of).
+Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).
 }
 \examples{
 T <- 24

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -2,56 +2,74 @@
 % Please edit documentation in R/qplot.R
 \name{agg_qplot}
 \alias{agg_qplot}
-\title{RBA-style graphs in R}
+\title{Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).}
 \usage{
-agg_qplot(data, series = NULL, x = NULL, bars = NULL,
+agg_qplot(data, series = NULL, x = NULL, bars = FALSE,
   filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
   sources = c(), yunits = NULL, col = list(), pch = list(),
-  lty = list(), lwd = list(), xlim = list(), ylim = list(),
+  lty = list(), lwd = list(), xlim = NULL, ylim = NULL,
   legend = FALSE, legend.ncol = NA, bar.stacked = TRUE)
 }
 \arguments{
-\item{data}{Object containing the series you want to plot. Can be a data.frame, tibble or ts. Can also be a list of the above, with separate for each panel.}
+\item{data}{Object containing the series you want to plot. Can be a `data.frame`,
+`tibble`, `zoo`, `xts` or `ts`.}
 
 \item{series}{A vector of series names specifying which subset of series
 you want to plot.}
 
-\item{x}{The x variable for your plot. `ts`, `xts` and `zoo` data use the dates in the time series.}
+\item{x}{The x variable for your plot. Not required for `ts`, `xts` and `zoo`
+data because they use the dates in the time series.}
 
-\item{bars}{(optional) Vector of string names indicating which series should be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series will plot as bars.}
+\item{bars}{(optional) Vector of string names indicating which series should
+be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series
+will plot as bars.}
 
-\item{filename}{(optional) If specified, save image to filename instead of displaying in R. Supports pdf, emf and png extensions.}
+\item{filename}{(optional) If specified, save image to filename instead of
+displaying in R. Supports svg, pdf, emf, emf+ and png extensions.}
 
-\item{title}{(optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.}
+\item{title}{(optional) A string indicating the title for the graph. Passing
+`NULL` (or omitting the argument) will suppress printing of title.}
 
-\item{subtitle}{(optional) A string indicating the subtitle for the entire chart. Passing NULL (or omitting the argument) will suppress printing of subtitle.}
+\item{subtitle}{(optional) A string indicating the subtitle for the graph.
+Passing `NULL` (or omitting the argument) will suppress printing of subtitle.}
 
 \item{footnotes}{(optional) A vector strings, corresponding to the footnotes, in order.}
 
 \item{sources}{(optional) A vector of strings, one entry for each source.}
 
-\item{yunits}{(optional) A list of string -> string pairs indicating the units to be used on each panel (/axes, see notes to series for explanation on how right-hand-side axes are treated). Alternatively, providing just a string will assign that to all panels. If not supplied, a per cent sign will be used.}
+\item{yunits}{(optional) A string indicating the units to be used. If not
+supplied, a % sign will be used.}
 
-\item{col}{(optional) A list of string -> misc pairs. The keys should be series names, and the values colours for each series (any colour accepted by R is fine.) You need not supply colours for all series. Default colours will be assigned  (cycling through) to series without assigned colours. Alternatively, you can supply a single value to apply to all series.}
+\item{col}{(optional) A list of string -> misc pairs. The keys should be
+series names, and the values colours for each series (any colour accepted by
+R is fine.) You need not supply colours for all series. Default colours will
+be assigned  (cycling through) to series without assigned colours.
+Alternatively, you can supply a single value to apply to all series.}
 
-\item{pch}{(optional) A list of string -> int pairs. The keys should be series names, and the values markers (pch values) for each series. Defaults to none (NA). Can be supplied as list, or a single value (which will be applied to all series).}
+\item{pch}{(optional) Markers for your series. Passed as with `col`.
+Defaults to none (NA).}
 
-\item{lty}{(optional) A list of string -> int pairs. The keys should be series names, and the values line types (lty values) for each series. Defaults to solid (1). Can be supplied as list, or a single value (which will be applied to all series).}
+\item{lty}{(optional) Line types for each series.  Passed as with `col`.
+Defaults to solid (1).}
 
-\item{lwd}{(optional) A list of string -> numeric pairs. The keys should be series names, and the values line width, relative to default, for each series. Defaults to 1. Can be supplied as list, or a single value (which will be applied to all series).}
+\item{lwd}{(optional) Line width, relative to default, for each series.
+Passed as with `col`.}
 
-\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph. Alternatively, you can supply a list to provide different x limits for each panel (not recommended). If unsupplied, a suitable default is chosen (recommended).}
+\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph.}
 
-\item{ylim}{(optional) A list of string -> list(min = numeric, max = numeric, nsteps int) pairs. Keys are panel names (e.g. "1", "2", etc). Values are the scale, provided as a list with the keys min, max and nsteps. If unsupplied, a suitable default is chosen (recommended, but will not work well for multipanels).}
+\item{ylim}{(optional) A list(min = numeric, max = numeric, nsteps int).
+If unsupplied, a suitable default is chosen.}
 
 \item{legend}{A logical indicating whether to add a legend to the graph (default FALSE).}
 
-\item{legend.ncol}{How many columns do you want the legend to have (if NA, which is the default, arphit will guess for you).}
+\item{legend.ncol}{(optional) How many columns do you want the legend to have (if NA,
+which is the default, arphit will guess for you).}
 
-\item{bar.stacked}{(optional) Logical indicating whether the bar series should be stacked (TRUE, default) or side-by-side (FALSE).}
+\item{bar.stacked}{(optional) Logical indicating whether the bar series should
+be stacked (TRUE, default) or side-by-side (FALSE).}
 }
 \description{
-Quickly creates a (potentially multipanel) graph. Supports bar and line (and combinations of).
+Quick plot - for quickly creates a single-panel graph. Supports bar and line (and combinations of).
 }
 \examples{
 T <- 24

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -4,51 +4,69 @@
 \alias{agg_qplot}
 \title{RBA-style graphs in R}
 \usage{
-agg_qplot(data, series = NULL, x = NULL, bars = NULL,
+agg_qplot(data, series = NULL, x = NULL, bars = FALSE,
   filename = NULL, title = NULL, subtitle = NULL, footnotes = c(),
   sources = c(), yunits = NULL, col = list(), pch = list(),
-  lty = list(), lwd = list(), xlim = list(), ylim = list(),
+  lty = list(), lwd = list(), xlim = NULL, ylim = NULL,
   legend = FALSE, legend.ncol = NA, bar.stacked = TRUE)
 }
 \arguments{
-\item{data}{Object containing the series you want to plot. Can be a data.frame, tibble or ts. Can also be a list of the above, with separate for each panel.}
+\item{data}{Object containing the series you want to plot. Can be a `data.frame`,
+`tibble`, `zoo`, `xts` or `ts`.}
 
 \item{series}{A vector of series names specifying which subset of series
 you want to plot.}
 
-\item{x}{The x variable for your plot. `ts`, `xts` and `zoo` data use the dates in the time series.}
+\item{x}{The x variable for your plot. Not required for `ts`, `xts` and `zoo`
+data because they use the dates in the time series.}
 
-\item{bars}{(optional) Vector of string names indicating which series should be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series will plot as bars.}
+\item{bars}{(optional) Vector of string names indicating which series should
+be bars, rather than lines. Alternatively, if you set `bars = TRUE` all series
+will plot as bars.}
 
-\item{filename}{(optional) If specified, save image to filename instead of displaying in R. Supports pdf, emf and png extensions.}
+\item{filename}{(optional) If specified, save image to filename instead of
+displaying in R. Supports svg, pdf, emf, emf+ and png extensions.}
 
-\item{title}{(optional) A string indicating the title for the entire chart. Passing NULL (or omitting the argument) will suppress printing of title.}
+\item{title}{(optional) A string indicating the title for the graph. Passing
+`NULL` (or omitting the argument) will suppress printing of title.}
 
-\item{subtitle}{(optional) A string indicating the subtitle for the entire chart. Passing NULL (or omitting the argument) will suppress printing of subtitle.}
+\item{subtitle}{(optional) A string indicating the subtitle for the graph.
+Passing `NULL` (or omitting the argument) will suppress printing of subtitle.}
 
 \item{footnotes}{(optional) A vector strings, corresponding to the footnotes, in order.}
 
 \item{sources}{(optional) A vector of strings, one entry for each source.}
 
-\item{yunits}{(optional) A list of string -> string pairs indicating the units to be used on each panel (/axes, see notes to series for explanation on how right-hand-side axes are treated). Alternatively, providing just a string will assign that to all panels. If not supplied, a per cent sign will be used.}
+\item{yunits}{(optional) A string indicating the units to be used. If not
+supplied, a % sign will be used.}
 
-\item{col}{(optional) A list of string -> misc pairs. The keys should be series names, and the values colours for each series (any colour accepted by R is fine.) You need not supply colours for all series. Default colours will be assigned  (cycling through) to series without assigned colours. Alternatively, you can supply a single value to apply to all series.}
+\item{col}{(optional) A list of string -> misc pairs. The keys should be
+series names, and the values colours for each series (any colour accepted by
+R is fine.) You need not supply colours for all series. Default colours will
+be assigned  (cycling through) to series without assigned colours.
+Alternatively, you can supply a single value to apply to all series.}
 
-\item{pch}{(optional) A list of string -> int pairs. The keys should be series names, and the values markers (pch values) for each series. Defaults to none (NA). Can be supplied as list, or a single value (which will be applied to all series).}
+\item{pch}{(optional) Markers for your series. Passed as with `col`.
+Defaults to none (NA).}
 
-\item{lty}{(optional) A list of string -> int pairs. The keys should be series names, and the values line types (lty values) for each series. Defaults to solid (1). Can be supplied as list, or a single value (which will be applied to all series).}
+\item{lty}{(optional) Line types for each series.  Passed as with `col`.
+Defaults to solid (1).}
 
-\item{lwd}{(optional) A list of string -> numeric pairs. The keys should be series names, and the values line width, relative to default, for each series. Defaults to 1. Can be supplied as list, or a single value (which will be applied to all series).}
+\item{lwd}{(optional) Line width, relative to default, for each series.
+Passed as with `col`.}
 
-\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph. Alternatively, you can supply a list to provide different x limits for each panel (not recommended). If unsupplied, a suitable default is chosen (recommended).}
+\item{xlim}{(optional) c(numeric, numeric) Gives the x limits (in years) for the graph.}
 
-\item{ylim}{(optional) A list of string -> list(min = numeric, max = numeric, nsteps int) pairs. Keys are panel names (e.g. "1", "2", etc). Values are the scale, provided as a list with the keys min, max and nsteps. If unsupplied, a suitable default is chosen (recommended, but will not work well for multipanels).}
+\item{ylim}{(optional) A list(min = numeric, max = numeric, nsteps int).
+If unsupplied, a suitable default is chosen.}
 
 \item{legend}{A logical indicating whether to add a legend to the graph (default FALSE).}
 
-\item{legend.ncol}{How many columns do you want the legend to have (if NA, which is the default, arphit will guess for you).}
+\item{legend.ncol}{(optional) How many columns do you want the legend to have (if NA,
+which is the default, arphit will guess for you).}
 
-\item{bar.stacked}{(optional) Logical indicating whether the bar series should be stacked (TRUE, default) or side-by-side (FALSE).}
+\item{bar.stacked}{(optional) Logical indicating whether the bar series should
+be stacked (TRUE, default) or side-by-side (FALSE).}
 }
 \description{
 Quickly creates a (potentially multipanel) graph. Supports bar and line (and combinations of).

--- a/man/agg_qplot.Rd
+++ b/man/agg_qplot.Rd
@@ -38,7 +38,7 @@ Passing `NULL` (or omitting the argument) will suppress printing of subtitle.}
 \item{sources}{(optional) A vector of strings, one entry for each source.}
 
 \item{yunits}{(optional) A string indicating the units to be used. If not
-supplied, a % sign will be used.}
+supplied, a \% sign will be used.}
 
 \item{col}{(optional) A list of string -> misc pairs. The keys should be
 series names, and the values colours for each series (any colour accepted by

--- a/tests/testthat/test-qplot.R
+++ b/tests/testthat/test-qplot.R
@@ -12,10 +12,10 @@ test_that("Simple smoke tests of qplot", {
 test_that("Errors for wrong x vars", {
   data <- data.frame(x=1:10,y=rnorm(10))
   expect_error(agg_qplot(data, x="x1"),
-               "The x variable you specified (x1) is not in your data.",
+               "x1 is not in your data for panel 1",
                fixed = TRUE)
   expect_error(agg_qplot(data),
-               "You did not specify an x variable and cannot guess it because your data is not a time series.",
+               "Cannot add layer. You have not specified an x aesthetic (and there was not one to inherit).",
                fixed = TRUE)
 })
 

--- a/tests/testthat/test-qplot.R
+++ b/tests/testthat/test-qplot.R
@@ -11,6 +11,7 @@ test_that("Simple smoke tests of qplot", {
 
 test_that("Errors for wrong x vars", {
   data <- data.frame(x=1:10,y=rnorm(10))
+  skip("This is throwing the wrong error at the moment. Will be fixed by #223.")
   expect_error(agg_qplot(data, x="x1"),
                "x1 is not in your data for panel 1",
                fixed = TRUE)

--- a/tests/testthat/test-qplot.R
+++ b/tests/testthat/test-qplot.R
@@ -7,6 +7,8 @@ test_that("Simple smoke tests of qplot", {
   data <- ts(data.frame(y=rnorm(10),y2=rnorm(10),y3=rnorm(10)), frequency = 4, start = 2000)
   expect_error(agg_qplot(data, series = c("y","y2")), NA)
   expect_error(agg_qplot(data, series = c("y","y2"), bars = TRUE), NA)
+  expect_error(agg_qplot(data, xlim = c(2000,2010),ylim=list(min=-10,max=10,nsteps=5),legend=TRUE,pch=19), NA)
+  expect_error(agg_qplot(data, pch=NULL), NA)
 })
 
 test_that("Errors for wrong x vars", {

--- a/tests/testthat/test-xvars.R
+++ b/tests/testthat/test-xvars.R
@@ -81,7 +81,8 @@ test_that("Time series graphs at different frequencies", {
 test_that("Error handling", {
   expect_error(
     agg_qplot(data.frame(y=1:10)),
-    "You did not specify an x variable and cannot guess it because your data is not a time series."
+    "Cannot add layer. You have not specified an x aesthetic (and there was not one to inherit).",
+    fixed = TRUE
   )
 })
 


### PR DESCRIPTION
Goes further than #242, but only on internals.  Converts qplot to work by just converting the plotting call to a call to the gg-interface. This makes the code much easier to maintain, as the qplot interface is now entirely separable from the internals of `agg_draw`, and relies only on exported and documented features of the gg-interface. Eases the implementation of #223, by reducing how much code relies on internal features.