### PR TITLE
More test helpers

### DIFF
--- a/tests/testthat/helper-test-check.R
+++ b/tests/testthat/helper-test-check.R
@@ -1,4 +1,4 @@
-check_graph <- function(p, filename) {
+check_graph <- function(p, filename, max_distortion = 0.97) {
   comp_location <- paste0(tempdir(), "/", filename, ".png")
   agg_draw(p, comp_location)
 
@@ -14,7 +14,7 @@ check_graph <- function(p, filename) {
     # Check that image similarity greater than 97%. The same graph exported on
     # different machines have _slight_ differences for some reason.
     dist <- magick::image_compare_dist(comparison, reference)$distortion
-    if (dist > 0.97) {
+    if (dist >= max_distortion) {
       return(TRUE)
     } else {
       cat(paste0("\n", filename, " does not match (distortion of ", round(dist,3),")\n"))

--- a/tests/testthat/helper-test-check.R
+++ b/tests/testthat/helper-test-check.R
@@ -34,3 +34,19 @@ create_test <- function(p, filename) {
   }
   agg_draw(p, filename = reference_loc)
 }
+
+delete_test <- function(filename) {
+  reference_loc_w <- paste0("tests/testdata/windows/", filename, ".png")
+  reference_loc_l <- paste0("tests/testdata/linux/", filename, ".png")
+  file.remove(reference_loc_w)
+  file.remove(reference_loc_l)
+}
+
+show_reference <- function(filename) {
+  if (.Platform$OS.type == "windows") {
+    reference_loc <- paste0("tests/testdata/windows/", filename, ".png")
+  } else {
+    reference_loc <- paste0("tests/testdata/linux/", filename, ".png")
+  }
+  magick::image_read(reference_loc)
+}

--- a/tests/testthat/test-notes.R
+++ b/tests/testthat/test-notes.R
@@ -12,12 +12,12 @@ test_that("Title", {
   p <- arphitgg() +
     agg_title("This is a veeeeeerrrrrryy loooooooooonnnnnnngg title that should break across lines") +
     agg_title("This is a veeeeeerrrrrryy loooooooooonnnnnnngg panel title too", panel = "1")
-  expect_true(check_graph(p, "notes-long-title"))
+  expect_true(check_graph(p, "notes-long-title", 0.925)) # Needs lower distortion because is text heavy
 
   p <- arphitgg() +
     agg_title("This is a veeeeeerrrrrryy\nloooooooooonnnnnnngg title\nwith manual line breaks") +
     agg_title("And manual\nline\nbreaks in a veeeeeeeeeeeeeeeeeeeeeerrrrrrryyyyy loong title", panel = "1")
-  expect_true(check_graph(p, "notes-long-title-manual-breaks"))
+  expect_true(check_graph(p, "notes-long-title-manual-breaks", 0.945)) # Needs lower distortion because is text heavy
 })
 
 
@@ -47,7 +47,7 @@ test_that("Subtitle and title", {
     agg_subtitle("Now a subtitle, which is fun") +
     agg_title("Here's a title, and some other stuff", panel = "1") +
     agg_subtitle("Now a subtitle, which is fun", panel = "1")
-  expect_true(check_graph(p, "notes-title-and-subtitle"))
+  expect_true(check_graph(p, "notes-title-and-subtitle", 0.92)) # Needs lower distortion because is text heavy
 })
 
 ## Footnotes ===================

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -15,11 +15,10 @@ test_that("Reference files for linux and windows exist for all tests", {
     cat(paste0("The following linux tests have no windows reference: ", linux[!linux %in% win], "\n"))
   }
 
+  skip("Blocked by #246")
   expect_false(any(!win %in% used_tests))
   if (any(!win %in% used_tests)) {
     cat(paste0("The following test reference files were never used: ", win[!win %in% used_tests], "\n"))
   }
-
-
 })
 

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -15,7 +15,6 @@ test_that("Reference files for linux and windows exist for all tests", {
     cat(paste0("The following linux tests have no windows reference: ", linux[!linux %in% win], "\n"))
   }
 
-  skip("Blocked by #246")
   expect_false(any(!win %in% used_tests))
   if (any(!win %in% used_tests)) {
     cat(paste0("The following test reference files were never used: ", win[!win %in% used_tests], "\n"))

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -2,6 +2,7 @@ context("Cross-platform test checking")
 
 win <- list.files("../testdata/windows/")
 linux <- list.files("../testdata/linux/")
+used_tests <- list.files(tempdir(), ".*\\.png")
 
 test_that("Reference files for linux and windows exist for all tests", {
   expect_false(any(!win %in% linux))
@@ -13,5 +14,12 @@ test_that("Reference files for linux and windows exist for all tests", {
   if (any(!linux %in% win)) {
     cat(paste0("The following linux tests have no windows reference: ", linux[!linux %in% win], "\n"))
   }
+
+  expect_false(any(!win %in% used_tests))
+  if (any(!win %in% used_tests)) {
+    cat(paste0("The following test reference files were never used: ", win[!win %in% used_tests], "\n"))
+  }
+
+
 })
 


### PR DESCRIPTION
Add some extra test helper functions (delete test and show reference) and add a test to check that all the reference files are _used_ during testing.

Also allow some tests to have lower threshold for comparisons. This is needed for text-heavy tests, where small differences in fonts compound.