### PR TITLE
Fix up autolabeller arrows for line graphs

### DIFF
--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -197,7 +197,9 @@ autolabel_series <- function(label, p, data, plot_bitmap, los_mask, xlim, ylim, 
     graphics::plot(0, lwd = 0, pch = NA, axes = FALSE, xlab = "", ylab = "",
                    xlim = xlim[[p]], ylim = c(ylim[[p]]$min, ylim[[p]]$max))
     drawlabel(newlabel)
-    if (label$series_type != "bar" || arrows_bars) {
+    if (label$series_type != "bar") {
+      return(list(label=newlabel,arrow=add_arrow(found_location, newlabel$text, label$col, p, inches_conversion)))
+    } else if (arrows_bars) {
       return(list(label=newlabel,arrow=add_arrow(found_location, newlabel$text, label$fill, p, inches_conversion)))
     } else {
       return(list(label=newlabel))

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -189,7 +189,7 @@ test_that('Line of sight', {
     agg_xlim(1.5,10.5) +
     agg_autolabel(TRUE)
   expect_true(
-    check_graph(p, "autolabel-no-LOS")
+    check_graph(p, "autolabel-no-LOS", 0.995)
   )
 
   # Creating los mask failing for series outside the axes (#202)


### PR DESCRIPTION
Was not properly adding arrows because it was treating it as a bar series.

Closes #260 