### PR TITLE
Use CRAN version of covr instead of github dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: xenial
 warnings_are_errors: true
 sudo: false
 cache: packages
-r_github_packages:
-  - jimhester/covr
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
   - chmod 755 ./.push_gh_pages.sh
 
 after_success:
-  - Rscript -e 'covr::coveralls()'
+  - travis_wait 20 Rscript -e 'covr::coveralls()'
   - test $TRAVIS_BRANCH = "stable" && test $TRAVIS_PULL_REQUEST = "false" && ./.push_gh_pages.sh

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
 Suggests:
   testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    covr
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr


### PR DESCRIPTION
Builds have been timing out waiting for coveralls to respond to coverage results. See if downgrading the covr package helps.

Closes #266 