### PR TITLE
Error if ordering variable classes clash

### DIFF
--- a/R/gg-add-layers.R
+++ b/R/gg-add-layers.R
@@ -155,6 +155,12 @@ reorder_series <- function(gg, data, aes, panel) {
   }
 
   # combine the existing order mapping with the new one and get unique entries
+  if (!is.null(gg$data[[panel]]$order_mapping$order) &&
+      class(new_order_mapping$order) != class(gg$data[[panel]]$order_mapping$order) &&
+      !((class(new_order_mapping$order)=="integer" && class(gg$data[[panel]]$order_mapping$order)=="numeric") ||
+        (class(gg$data[[panel]]$order_mapping$order)=="integer" && class(new_order_mapping$order)=="numeric"))) {
+    stop(paste0("Do not know how to join together ordering variables with classes ", class(new_order_mapping$order), " and ", class(gg$data[[panel]]$order_mapping$order), " (panel ", panel, "). Perhaps you added layers to the same panel with different ordering variables (or didn't specify an ordering variable for one of the layers)?"))
+  }
   gg$data[[panel]]$order_mapping <- unique(rbind(new_order_mapping, gg$data[[panel]]$order_mapping))
 
   # Check for ambiguity

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -201,6 +201,15 @@ test_that("Error messages", {
     "Do not know how to join together x values character and integer (panel 1)",
     fixed = TRUE
   )
+
+  data <- data.frame(x=letters[1:10],y=1:10)
+  epxect_error(
+    arphitgg() +
+      agg_col(data = filter(data, x != "c"), aes = agg_aes(x = x, y = y, order = y)) +
+      agg_col(data = filter(data, x == "c"), aes = agg_aes(x = x, y = y)),
+    "Do not know how to join together ordering variables with classes character and integer (panel 1). Perhaps you added layers to the same panel with different ordering variables (or didn't specify an ordering variable for one of the layers)?",
+    fixed = TRUE
+  )
 })
 
 ## Ordering ====================

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -203,7 +203,7 @@ test_that("Error messages", {
   )
 
   data <- data.frame(x=letters[1:10],y=1:10)
-  epxect_error(
+  expect_error(
     arphitgg() +
       agg_col(data = filter(data, x != "c"), aes = agg_aes(x = x, y = y, order = y)) +
       agg_col(data = filter(data, x == "c"), aes = agg_aes(x = x, y = y)),


### PR DESCRIPTION
Throw error if classes of ordering variable do not reconcile, rather than relying on likely misleading promote rules