### PR TITLE
Fix excel exporting converting characters to factors

### DIFF
--- a/R/write-xlsx.R
+++ b/R/write-xlsx.R
@@ -1,7 +1,9 @@
 create_data_panel <- function(panel, data) {
   df <- data.frame(agg_x_variable = panel$x, stringsAsFactors = FALSE)
   for (i in seq_along(panel$series)) {
-    newdf <- data.frame(agg_x_variable = series_x_values(panel, i), y = series_values(panel, i))
+    newdf <- data.frame(agg_x_variable = series_x_values(panel, i),
+                        y = series_values(panel, i),
+                        stringsAsFactors = FALSE)
     names(newdf) <- c("agg_x_variable", panel$series[[i]]$name)
     df <- dplyr::full_join(df, newdf, by = "agg_x_variable")
   }
@@ -18,7 +20,8 @@ write_to_excel <- function(gg, filename) {
   metadata <-
     data.frame(
       Metadata = metadata_names,
-      Value = metadata_values
+      Value = metadata_values,
+      stringsAsFactors = FALSE
     )
 
   panels <- lapply(gg$data, create_data_panel, data = gg$data)

--- a/tests/testthat/test-write-xlsx.R
+++ b/tests/testthat/test-write-xlsx.R
@@ -32,3 +32,10 @@ test_that("Smoke tests", {
   agg_draw(p, "test-2.xlsx")
   expect_true(file.exists("test-2.xlsx"))
 })
+
+test_that("Characters coerced to factors (#280)", {
+  foo <- data.frame(date = "AAA", x = letters[1:10],y=rnorm(10),z=rnorm(10),stringsAsFactors = FALSE)
+  p <- arphitgg(foo, agg_aes(x=x,y=y,group=date)) + agg_col() + agg_col(agg_aes(y=z)) + agg_autolabel()
+  expect_warning(agg_draw(p, "foo.xlsx"), NA)
+  file.remove("foo.xlsx")
+})


### PR DESCRIPTION
Was throwing warnings when exporting graphs with numeric x variables because they were being merged after being convered to factors. Closes #280.