### PR TITLE
Only run travis on master and stable branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ warnings_are_errors: true
 sudo: false
 cache: packages
 
+branches:
+  only:
+    - master
+    - stable
+
 addons:
   apt:
     update: true


### PR DESCRIPTION
Still run for all PRs, but don't unnecessarily also run branch builds on all branches. Only need master (for badges) and stable (for docs).