### PR TITLE
Replace color with colour

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,11 +10,11 @@
 
 ## Breaking changes
 
- * `color` has been replaced with `colour` everywhere. The package was inconsistent
- in its spelling, so this has all been harmonised on the Australian spelling.
- Code using `color` will continue to work for now, with a warning. But it  will be
- an error in future versions, so you should update code now ([#296](https://github.com/angusmoore/arphit/pull/293)).
-
 ## Bugfixes
 
 ## Deprecated or removed
+
+* `color` has been replaced with `colour` everywhere. The package was inconsistent
+ in its spelling, so this has all been harmonised on the Australian spelling.
+ Code using `color` will continue to work for now, with a warning. But it  will be
+ an error in future versions, so you should update code now ([#296](https://github.com/angusmoore/arphit/pull/293)).

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,13 @@
  for the right hand side. Vertically divided time series graphs always add a margin. 
  ([#292](https://github.com/angusmoore/arphit/pull/292))
  * Export a list of graphs as a GIF animation ([#293](https://github.com/angusmoore/arphit/pull/293))
+
 ## Breaking changes
+
+ * `color` has been replaced with `colour` everywhere. The package was inconsistent
+ in its spelling, so this has all been harmonised on the Australian spelling.
+ Code using `color` will continue to work for now, with a warning. But it  will be
+ an error in future versions, so you should update code now ([#296](https://github.com/angusmoore/arphit/pull/293)).
 
 ## Bugfixes
 

--- a/R/annotations.R
+++ b/R/annotations.R
@@ -46,7 +46,7 @@ drawbgshading <- function(shading) {
   if (is.na(shading$y2)) {
     shading$y2 <- graphics::par("usr")[4]
   }
-  graphics::rect(shading$x1, shading$y1, shading$x2, shading$y2, col = shading$color, lty = 0)
+  graphics::rect(shading$x1, shading$y1, shading$x2, shading$y2, col = shading$colour, lty = 0)
 }
 
 drawbgshadings <- function(shadings, p) {
@@ -71,7 +71,7 @@ drawannotationline <- function(line) {
   if (is.na(line$y2)) {
     line$y2 <- graphics::par("usr")[4]
   }
-  graphics::segments(line$x1, line$y1, line$x2, line$y2, col = line$color, lty = line$lty, lwd = line$lwd)
+  graphics::segments(line$x1, line$y1, line$x2, line$y2, col = line$colour, lty = line$lty, lwd = line$lwd)
 }
 
 drawannotationlines <- function(lines, p) {
@@ -83,7 +83,7 @@ drawannotationlines <- function(lines, p) {
 }
 
 drawlabel <- function(label) {
-  graphics::text(label$text, x = label$x, y = label$y, adj = c(0.5, 0.5), col = label$color, cex = label$cex)
+  graphics::text(label$text, x = label$x, y = label$y, adj = c(0.5, 0.5), col = label$colour, cex = label$cex)
 }
 
 drawlabels <- function(labels, p) {
@@ -95,7 +95,7 @@ drawlabels <- function(labels, p) {
 }
 
 drawarrow <- function(arrow) {
-  graphics::arrows(arrow$tail.x, arrow$tail.y, arrow$head.x, arrow$head.y, col = arrow$color, lwd = arrow$lwd, length = 0.1)
+  graphics::arrows(arrow$tail.x, arrow$tail.y, arrow$head.x, arrow$head.y, col = arrow$colour, lwd = arrow$lwd, length = 0.1)
 }
 
 drawarrows <- function(arrows, p) {

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -13,10 +13,10 @@ handleattribute <- function(data, att, default) {
 
 handleattributes <- function(data) {
   for (p in names(data)) {
-    if (is.null(getOption("arphit.user_colors"))) {
-      data[[p]] <- handleattribute(data[[p]], "col", DEFAULTCOLORS)
+    if (is.null(getOption("arphit.user_colours"))) {
+      data[[p]] <- handleattribute(data[[p]], "col", DEFAULTCOLOURS)
     } else {
-      data[[p]] <- handleattribute(data[[p]], "col", getOption("arphit.user_colors"))
+      data[[p]] <- handleattribute(data[[p]], "col", getOption("arphit.user_colours"))
     }
   	data[[p]] <- handleattribute(data[[p]], "pch", DEFAULTPCH)
   	data[[p]] <- handleattribute(data[[p]], "lty", DEFAULTLTY)

--- a/R/autolabel-utils.R
+++ b/R/autolabel-utils.R
@@ -137,7 +137,7 @@ bounding_box_intersection <- function(x,y,a,b,h,w) {
   return(intersections[!sapply(intersections, is.null)][[1]])
 }
 
-add_arrow <- function(found_location, text, color, p, inches_conversion) {
+add_arrow <- function(found_location, text, colour, p, inches_conversion) {
   if ((!found_location$los && found_location$distance > 0.1) || found_location$distance > 1.5) {
     # adjust the tail to the edge of the bounding box
     adjusted <-
@@ -155,7 +155,7 @@ add_arrow <- function(found_location, text, color, p, inches_conversion) {
                        tail.y = adjusted$y,
                        head.x = found_location$xx,
                        head.y = found_location$yy,
-                       color = color,
+                       colour = colour,
                        panel = p)
       drawarrow(newarrow)
     } else {

--- a/R/autolabel.R
+++ b/R/autolabel.R
@@ -187,7 +187,7 @@ autolabel_series <- function(label, p, data, plot_bitmap, los_mask, xlim, ylim, 
   if (!is.null(found_location)) {
     newlabel <- list(
       text = label$label,
-      color = label$series$attributes$col,
+      colour = label$series$attributes$col,
       x = found_location$x,
       y = found_location$y,
       panel = p

--- a/R/colpal.R
+++ b/R/colpal.R
@@ -130,7 +130,7 @@ RBA["Grey8"] <- rgb(51, 51, 51, maxColorValue = 255)
 RBA["Grey9"] <- rgb(26, 26, 26, maxColorValue = 255)
 RBA["Grey10"] <- rgb(0, 0, 0, maxColorValue = 255)
 
-# Add aliases for default colors
+# Add aliases for default colours
 RBA["Default1"] <- RBA["Aqua8"]
 RBA["Default2"] <- RBA["Orange2"]
 RBA["Default3"] <- RBA["DarkGreen7"]

--- a/R/constants.R
+++ b/R/constants.R
@@ -1,4 +1,4 @@
-DEFAULTCOLORS <- c(RBA["Aqua8"], RBA["Orange2"], RBA["DarkGreen7"], RBA["Violet1"], RBA["Blue7"], RBA["Red5"], RBA["Brown4"], RBA["Pink2"], RBA["Grey7"])
+DEFAULTCOLOURS <- c(RBA["Aqua8"], RBA["Orange2"], RBA["DarkGreen7"], RBA["Violet1"], RBA["Blue7"], RBA["Red5"], RBA["Brown4"], RBA["Pink2"], RBA["Grey7"])
 CSI <- 0.2
 LANDSCAPESIZE <- c(0.736842 * 7.5,7.5)
 PORTRAITSIZE <- c(10, 7.5)

--- a/R/data.R
+++ b/R/data.R
@@ -50,14 +50,14 @@ series_names <- function(x) {
 }
 
 get_bar_data <- function(data) {
-  colors <- c()
+  colours <- c()
   bordercol <- c()
   bardata <- data.frame(x = data$x, stringsAsFactors = FALSE)
 
   for (i in seq_along(data$series)) {
     s <- data$series[[i]]
     if (s$bar) {
-      colors <- append(colors, s$attributes$col)
+      colours <- append(colours, s$attributes$col)
       bordercol <- append(bordercol, s$attributes$barcol)
       series_data <- data.frame(x = series_x_values(data, i), y = series_values(data, i), stringsAsFactors = FALSE)
       names(series_data) <- c("x", i)
@@ -68,7 +68,7 @@ get_bar_data <- function(data) {
     }
   }
   bardata <- dplyr::select_(bardata, "-x")
-  return(list(bardata=bardata, colors=colors, bordercol=bordercol))
+  return(list(bardata=bardata, colours=colours, bordercol=bordercol))
 }
 
 convert_to_plot_bardata <- function(bardata, data) {

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -315,7 +315,7 @@ drawshading <- function(shading, data) {
     shading_data <- data.frame(x = c(x_to,rev(x_from)),
                                y = c(y_to,rev(y_from)))
     shading_data <- shading_data[!is.na(shading_data$x) & !is.na(shading_data$y), ]
-    graphics::polygon(shading_data$x,shading_data$y,col = s$color, border = NA)
+    graphics::polygon(shading_data$x,shading_data$y,col = s$colour, border = NA)
   }
 }
 
@@ -381,7 +381,7 @@ as.barplot.x <- function(bp.data, x, xlim, bar.stacked, log_scale) {
 drawbars <- function(l, data, xlim, ylim, bar.stacked, log_scale) {
   out <- get_bar_data(data)
   bardata <- out$bardata
-  colors <- out$colors
+  colours <- out$colours
   bordercol <- out$bordercol
 
   if (ncol(bardata) > 0) {
@@ -392,9 +392,9 @@ drawbars <- function(l, data, xlim, ylim, bar.stacked, log_scale) {
 
     xlim <- as.barplot.x(bardata_p, bar_x_loc, xlim, bar.stacked)
     graphics::par(mfg = l)
-    graphics::barplot(bardata_p, col = colors, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
+    graphics::barplot(bardata_p, col = colours, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
     graphics::par(mfg = l)
-    graphics::barplot(bardata_n, col = colors, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
+    graphics::barplot(bardata_n, col = colours, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
   }
 }
 

--- a/R/gg-add-layers.R
+++ b/R/gg-add-layers.R
@@ -286,7 +286,7 @@ addlayer <- function(gg, new, panel, bar) {
 }
 
 applylineattributes <- function(gg, newline, panel, newseries) {
-  gg <- applyattribute(gg, "col", panel, newseries, newline$color)
+  gg <- applyattribute(gg, "col", panel, newseries, newline$colour)
   gg <- applyattribute(gg, "pch", panel, newseries, newline$pch)
   gg <- applyattribute(gg, "lty", panel, newseries, newline$lty)
   gg <- applyattribute(gg, "lwd", panel, newseries, newline$lwd)

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -177,7 +177,7 @@ agg_footnote <- function(footnote) {
 agg_label <- function(text, x, y, panel, colour = "black", color, size = 20) {
   check_panel(panel)
   if (!missing(color)) {
-    warning("color has been deprecated. Please use `colour` instead.")
+    warning("color is deprecated; use colour instead")
     colour <- color
   }
   return(list(type = "label", text = text, colour = colour, x = x, y = y, panel = panel, cex = size / 20))

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -164,8 +164,8 @@ agg_footnote <- function(footnote) {
 #' @param y The y coordinate of the center of your label
 #' @param panel Which panel should the label be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the label to multiple panels at once.
 #' @param colour The colour of your text
-#' @param color (Deprecated; use colour instead) The colour of your text
 #' @param size Font size (default 20)
+#' @param color (Deprecated; use colour instead) The colour of your text
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -174,7 +174,7 @@ agg_footnote <- function(footnote) {
 #' arphitgg() + agg_label("Here is a label", 2003, 0.2, "1", RBA["Red3"])
 #'
 #' @export
-agg_label <- function(text, x, y, panel, colour = "black", color, size = 20) {
+agg_label <- function(text, x, y, panel, colour = "black", size = 20, color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")
@@ -213,9 +213,9 @@ agg_autolabel <- function(quiet = FALSE, arrow_bars = FALSE) {
 #' @param head.x The x coordinate of the arrow head
 #' @param head.y The y coordinate of the arrow head
 #' @param colour The colour of the arrow
-#' @param color (Deprecated; use colour instead) The colour of the arrow
 #' @param panel Which panel should the arrow be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the arrow to multiple panels at once.
 #' @param lwd (Optional, default 1) The linewidth of the arrow
+#' @param color (Deprecated; use colour instead) The colour of the arrow
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -226,7 +226,7 @@ agg_autolabel <- function(quiet = FALSE, arrow_bars = FALSE) {
 #'             color = RBA["Blue1"], panel = "1")
 #'
 #' @export
-agg_arrow <- function(tail.x, tail.y, head.x, head.y, colour = "black", color, panel, lwd = 1) {
+agg_arrow <- function(tail.x, tail.y, head.x, head.y, colour = "black", panel, lwd = 1, color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")
@@ -247,10 +247,10 @@ agg_arrow <- function(tail.x, tail.y, head.x, head.y, colour = "black", color, p
 #' @param x2 For specific AB lines: the second x coordinate
 #' @param y2 For specific AB lines: the second y coordinate
 #' @param colour The colour of the AB line (default black)
-#' @param color (Deprecated; use colour instead) The colour of the AB line (default black)
 #' @param panel Which panel should the line be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the line to multiple panels at once.
 #' @param lwd (Optional, default 1) The linewidth
 #' @param lty (Optional, default 1) The line type
+#' @param color (Deprecated; use colour instead) The colour of the AB line (default black)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -264,7 +264,7 @@ agg_arrow <- function(tail.x, tail.y, head.x, head.y, colour = "black", color, p
 #'              colour = RBA["Blue1"], panel = "1")
 #'
 #' @export
-agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 = NULL, colour = "black", color, panel, lwd = 1, lty = 1) {
+agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 = NULL, colour = "black", panel, lwd = 1, lty = 1, color) {
   line <- list(x = x, y = y, x1 = x1, y1 = y1, x2 = x2, y2 = y2, colour = colour, panel = panel, lwd = lwd, lty = lty)
   line <- sanitycheckline(line)
   line$x <- NULL
@@ -284,8 +284,8 @@ agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 =
 #' @param x2 The top right x coordinate (omit to have the shading automatically snap to the edge of the panel)
 #' @param y2 The top right y coordinate (omit to have the shading automatically snap to the edge of the panel)
 #' @param colour (optional) The colour of the AB line (default grey)
-#' @param color (Deprecated; use colour instead) The colour of the AB line (default grey)
 #' @param panel Which panel should the background shading be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the shading to multiple panels at once.
+#' @param color (Deprecated; use colour instead) The colour of the AB line (default grey)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -295,7 +295,7 @@ agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 =
 #' arphitgg(data) + agg_bgshading(y1 = 0.5, y2 = -0.5, panel = "1")
 #'
 #' @export
-agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, colour = RBA["Grey2"], color, panel) {
+agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, colour = RBA["Grey2"], panel, color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")
@@ -308,9 +308,9 @@ agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, colour = RBA["Grey
 #'
 #' @param from The series name to shade from (if you have no group aesthetic, it will be the name of the y variable); if you have groups, it will (usually) be the group identifier. This can get more complicated if you have duplicate group names. If so, arphit appends .y to the group names, so try that.)
 #' @param to The name of the series to shade to
+#' @param panel (optional) Which panel are the relevant series in? (arphit will try to find them if you don't specify)
 #' @param colour (optional) The colour to shade between the series (default grey)
 #' @param color (Deprecated; use colour instead) The colour to shade between the series (default grey)
-#' @param panel (optional) Which panel are the relevant series in? (arphit will try to find them if you don't specify)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -414,12 +414,12 @@ agg_legend <- function(ncol = NULL) {
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
 #' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
-#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param pch A point marker to be applied to all series, or or (if your aesthetic has a group), a vector of pch values that will be cycled through to consecutive group elements. Any value accepted by R for pch can be used.
 #' @param lty A line type to be applied to all series, or or (if your aesthetic has a group), a vector of lty values that will be cycled through to consecutive group elements. Any value accepted by R for lty can be used.
 #' @param lwd A line width to be applied to all series, or or (if your aesthetic has a group), a vector of lwd values that will be cycled through to consecutive group elements. Any value accepted by R for lwd can be used.
 #' @param pointsize Scale the size of the points? (default 1)
 #' @param panel (default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -430,7 +430,7 @@ agg_legend <- function(ncol = NULL) {
 #' arphitgg(data) + agg_line(aes = agg_aes(x = date, y = unemployment, group = state), panel = "1")
 #'
 #' @export
-agg_line <- function(aes = NULL, data = NULL, colour = NULL, color, pch = NULL, lty = NULL, lwd = NULL, pointsize = 1, panel = "1") {
+agg_line <- function(aes = NULL, data = NULL, colour = NULL, pch = NULL, lty = NULL, lwd = NULL, pointsize = 1, panel = "1", color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")
@@ -456,10 +456,10 @@ agg_line <- function(aes = NULL, data = NULL, colour = NULL, color, pch = NULL, 
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
 #' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
-#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param barcol (optional) Outline colours for each bar series
 #' @param panel (default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.
 #' @param stacked (default = TRUE) Stack the bars, or group them?
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -470,7 +470,7 @@ agg_line <- function(aes = NULL, data = NULL, colour = NULL, color, pch = NULL, 
 #' arphitgg(data) + agg_col(aes = agg_aes(x = date, y = unemployment, group = state), panel = "1")
 #'
 #' @export
-agg_col <- function(aes = NULL, data = NULL, colour = NULL, color, barcol = NULL, panel = "1", stacked = TRUE) {
+agg_col <- function(aes = NULL, data = NULL, colour = NULL, barcol = NULL, panel = "1", stacked = TRUE, color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")
@@ -494,9 +494,9 @@ agg_col <- function(aes = NULL, data = NULL, colour = NULL, color, barcol = NULL
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
 #' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
-#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param pointsize Scale the size of the points? (default 1)
 #' @param panel (default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
 #' all the plotting options
@@ -506,7 +506,7 @@ agg_col <- function(aes = NULL, data = NULL, colour = NULL, color, barcol = NULL
 #' arphitgg(data) + agg_point(aes = agg_aes(x = x, y = y), panel = "1")
 #'
 #' @export
-agg_point <- function(aes = NULL, data = NULL, colour = NULL, color, pointsize = 1, panel = "1") {
+agg_point <- function(aes = NULL, data = NULL, colour = NULL, pointsize = 1, panel = "1", color) {
   check_panel(panel)
   if (!missing(color)) {
     warning("color is deprecated; use colour instead")

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -163,7 +163,8 @@ agg_footnote <- function(footnote) {
 #' @param x The x coordinate of the center of your label
 #' @param y The y coordinate of the center of your label
 #' @param panel Which panel should the label be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the label to multiple panels at once.
-#' @param color The color of your text
+#' @param colour The colour of your text
+#' @param color (Deprecated; use colour instead) The colour of your text
 #' @param size Font size (default 20)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
@@ -173,9 +174,13 @@ agg_footnote <- function(footnote) {
 #' arphitgg() + agg_label("Here is a label", 2003, 0.2, "1", RBA["Red3"])
 #'
 #' @export
-agg_label <- function(text, x, y, panel, color = "black", size = 20) {
+agg_label <- function(text, x, y, panel, colour = "black", color, size = 20) {
   check_panel(panel)
-  return(list(type = "label", text = text, color = color, x = x, y = y, panel = panel, cex = size / 20))
+  if (!missing(color)) {
+    warning("color has been deprecated. Please use `colour` instead.")
+    colour <- color
+  }
+  return(list(type = "label", text = text, colour = colour, x = x, y = y, panel = panel, cex = size / 20))
 }
 
 #' Add automatically placed label
@@ -207,7 +212,8 @@ agg_autolabel <- function(quiet = FALSE, arrow_bars = FALSE) {
 #' @param tail.y The y coordinate of the arrow tail
 #' @param head.x The x coordinate of the arrow head
 #' @param head.y The y coordinate of the arrow head
-#' @param color The color of the arrow
+#' @param colour The colour of the arrow
+#' @param color (Deprecated; use colour instead) The colour of the arrow
 #' @param panel Which panel should the arrow be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the arrow to multiple panels at once.
 #' @param lwd (Optional, default 1) The linewidth of the arrow
 #'
@@ -220,10 +226,14 @@ agg_autolabel <- function(quiet = FALSE, arrow_bars = FALSE) {
 #'             color = RBA["Blue1"], panel = "1")
 #'
 #' @export
-agg_arrow <- function(tail.x, tail.y, head.x, head.y, color = "black", panel, lwd = 1) {
+agg_arrow <- function(tail.x, tail.y, head.x, head.y, colour = "black", color, panel, lwd = 1) {
   check_panel(panel)
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
   return(list(type = "arrow", tail.x = tail.x, tail.y = tail.y, head.x = head.x,
-              head.y = head.y, color = color, panel = panel, lwd = lwd))
+              head.y = head.y, colour = colour, panel = panel, lwd = lwd))
 }
 
 #' Add an AB line to your graph
@@ -236,7 +246,8 @@ agg_arrow <- function(tail.x, tail.y, head.x, head.y, color = "black", panel, lw
 #' @param y1 For specific AB lines: the first y coordinate
 #' @param x2 For specific AB lines: the second x coordinate
 #' @param y2 For specific AB lines: the second y coordinate
-#' @param color (optional) The color of the AB line (default black)
+#' @param colour The colour of the AB line (default black)
+#' @param color (Deprecated; use colour instead) The colour of the AB line (default black)
 #' @param panel Which panel should the line be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the line to multiple panels at once.
 #' @param lwd (Optional, default 1) The linewidth
 #' @param lty (Optional, default 1) The line type
@@ -245,20 +256,24 @@ agg_arrow <- function(tail.x, tail.y, head.x, head.y, color = "black", panel, lw
 #' all the plotting options
 #'
 #' @examples
-#' arphitgg(data) + agg_abline(x = 2001, color = RBA["Blue1"], panel = "1") +
-#'   agg_abline(y = -0.5, color = RBA["Red1"], panel = "1")
+#' arphitgg(data) + agg_abline(x = 2001, colour = RBA["Blue1"], panel = "1") +
+#'   agg_abline(y = -0.5, colour = RBA["Red1"], panel = "1")
 #'
 #' arphitgg(data) +
 #'   agg_abline(x1 = 2000, y1 = -0.1, x2 = 2002, y2 = 0.5,
-#'              color = RBA["Blue1"], panel = "1")
+#'              colour = RBA["Blue1"], panel = "1")
 #'
 #' @export
-agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 = NULL, color = "black", panel, lwd = 1, lty = 1) {
-  line <- list(x = x, y = y, x1 = x1, y1 = y1, x2 = x2, y2 = y2, color = color, panel = panel, lwd = lwd, lty = lty)
+agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 = NULL, colour = "black", color, panel, lwd = 1, lty = 1) {
+  line <- list(x = x, y = y, x1 = x1, y1 = y1, x2 = x2, y2 = y2, colour = colour, panel = panel, lwd = lwd, lty = lty)
   line <- sanitycheckline(line)
   line$x <- NULL
   line$y <- NULL
   check_panel(panel)
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
   return(append(line, list(type = "abline")))
 }
 
@@ -268,7 +283,8 @@ agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 =
 #' @param y1 The bottom left y coordinate (omit to have the shading automatically snap to the edge of the panel)
 #' @param x2 The top right x coordinate (omit to have the shading automatically snap to the edge of the panel)
 #' @param y2 The top right y coordinate (omit to have the shading automatically snap to the edge of the panel)
-#' @param color (optional) The color of the AB line (default grey)
+#' @param colour (optional) The colour of the AB line (default grey)
+#' @param color (Deprecated; use colour instead) The colour of the AB line (default grey)
 #' @param panel Which panel should the background shading be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the shading to multiple panels at once.
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
@@ -279,16 +295,21 @@ agg_abline <- function(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL, y2 =
 #' arphitgg(data) + agg_bgshading(y1 = 0.5, y2 = -0.5, panel = "1")
 #'
 #' @export
-agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, color = RBA["Grey2"], panel) {
+agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, colour = RBA["Grey2"], color, panel) {
   check_panel(panel)
-  return(list(type = "bgshading", x1 = x1, y1 = y1, x2 = x2, y2 = y2, color = color, panel = panel))
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
+  return(list(type = "bgshading", x1 = x1, y1 = y1, x2 = x2, y2 = y2, colour = colour, panel = panel))
 }
 
 #' Add shading between series
 #'
 #' @param from The series name to shade from (if you have no group aesthetic, it will be the name of the y variable); if you have groups, it will (usually) be the group identifier. This can get more complicated if you have duplicate group names. If so, arphit appends .y to the group names, so try that.)
 #' @param to The name of the series to shade to
-#' @param color (optional) The color to shade between the series (default grey)
+#' @param colour (optional) The colour to shade between the series (default grey)
+#' @param color (Deprecated; use colour instead) The colour to shade between the series (default grey)
 #' @param panel (optional) Which panel are the relevant series in? (arphit will try to find them if you don't specify)
 #'
 #' @seealso \code{vignette("plotting-options", package = "arphit")} for a detailed description of
@@ -297,16 +318,20 @@ agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, color = RBA["Grey2
 #' @examples
 #' data <- data.frame(date = seq.Date(from = as.Date("2000-03-10"), length.out = 12, by = "month"),
 #'                    x1 = rnorm(12), x2 = rnorm(12))
-#' arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), color = RBA["Blue2"]) +
-#'    agg_line(agg_aes(y = x2), color = RBA["Red4"]) +
+#' arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), colour = RBA["Blue2"]) +
+#'    agg_line(agg_aes(y = x2), coluor = RBA["Red4"]) +
 #'    agg_shading(from = x1, to = x2)
 #'
 #' @export
-agg_shading <- function(from, to, panel = NULL, color = RBA["Grey2"]) {
+agg_shading <- function(from, to, panel = NULL, colour = RBA["Grey2"], color) {
   from <- as.character(deparse(substitute(from)))
   to <- as.character(deparse(substitute(to)))
   if (!is.null(panel)) check_panel(panel)
-  return(list(type = "shading", from = from, to = to, panel = panel, color = color))
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
+  return(list(type = "shading", from = from, to = to, panel = panel, colour = colour))
 }
 
 #' Specify the y scale for a graph
@@ -388,7 +413,8 @@ agg_legend <- function(ncol = NULL) {
 #'
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
-#' @param color A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param pch A point marker to be applied to all series, or or (if your aesthetic has a group), a vector of pch values that will be cycled through to consecutive group elements. Any value accepted by R for pch can be used.
 #' @param lty A line type to be applied to all series, or or (if your aesthetic has a group), a vector of lty values that will be cycled through to consecutive group elements. Any value accepted by R for lty can be used.
 #' @param lwd A line width to be applied to all series, or or (if your aesthetic has a group), a vector of lwd values that will be cycled through to consecutive group elements. Any value accepted by R for lwd can be used.
@@ -404,14 +430,18 @@ agg_legend <- function(ncol = NULL) {
 #' arphitgg(data) + agg_line(aes = agg_aes(x = date, y = unemployment, group = state), panel = "1")
 #'
 #' @export
-agg_line <- function(aes = NULL, data = NULL, color = NULL, pch = NULL, lty = NULL, lwd = NULL, pointsize = 1, panel = "1") {
+agg_line <- function(aes = NULL, data = NULL, colour = NULL, color, pch = NULL, lty = NULL, lwd = NULL, pointsize = 1, panel = "1") {
   check_panel(panel)
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
   return(
     list(
       type = "line",
       data = data,
       aes = aes,
-      color = color,
+      colour = colour,
       pch = pch,
       lty = lty,
       lwd = lwd,
@@ -425,7 +455,8 @@ agg_line <- function(aes = NULL, data = NULL, color = NULL, pch = NULL, lty = NU
 #'
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
-#' @param color A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param barcol (optional) Outline colours for each bar series
 #' @param panel (default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.
 #' @param stacked (default = TRUE) Stack the bars, or group them?
@@ -439,26 +470,31 @@ agg_line <- function(aes = NULL, data = NULL, color = NULL, pch = NULL, lty = NU
 #' arphitgg(data) + agg_col(aes = agg_aes(x = date, y = unemployment, group = state), panel = "1")
 #'
 #' @export
-agg_col <- function(aes = NULL, data = NULL, color = NULL, barcol = NULL, panel = "1", stacked = TRUE) {
-    check_panel(panel)
-    return(
-      list(
-        type = "col",
-        data = data,
-        aes = aes,
-        color = color,
-        barcol = barcol,
-        panel = as.character(panel),
-        stacked = stacked
-      )
-    )
+agg_col <- function(aes = NULL, data = NULL, colour = NULL, color, barcol = NULL, panel = "1", stacked = TRUE) {
+  check_panel(panel)
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
   }
+  return(
+    list(
+      type = "col",
+      data = data,
+      aes = aes,
+      colour = colour,
+      barcol = barcol,
+      panel = as.character(panel),
+      stacked = stacked
+    )
+  )
+}
 
 #' Add a scatter layer to an arphit plot.
 #'
 #' @param data The data to be used. Will inherit from parent if missing.
 #' @param aes The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.
-#' @param color A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param colour A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
+#' @param color (Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.
 #' @param pointsize Scale the size of the points? (default 1)
 #' @param panel (default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.
 #'
@@ -470,14 +506,18 @@ agg_col <- function(aes = NULL, data = NULL, color = NULL, barcol = NULL, panel 
 #' arphitgg(data) + agg_point(aes = agg_aes(x = x, y = y), panel = "1")
 #'
 #' @export
-agg_point <- function(aes = NULL, data = NULL, color = NULL, pointsize = 1, panel = "1") {
+agg_point <- function(aes = NULL, data = NULL, colour = NULL, color, pointsize = 1, panel = "1") {
   check_panel(panel)
+  if (!missing(color)) {
+    warning("color is deprecated; use colour instead")
+    colour <- color
+  }
   return(
     list(
       type = "line",
       data = data,
       aes = aes,
-      color = color,
+      colour = colour,
       pointsize = pointsize,
       pch = 16,
       lty = 0,

--- a/R/qplot.R
+++ b/R/qplot.R
@@ -127,10 +127,10 @@ agg_qplot <- function(data, series = NULL, x = NULL, bars = FALSE, filename = NU
     }
 
     if ((is.logical(bars) && bars) || (y %in% bars)) {
-      p <- p + agg_col(aes = aes, color = qplot_get_attribute(col, y))
+      p <- p + agg_col(aes = aes, colour = qplot_get_attribute(col, y))
     } else {
       p <- p + agg_line(aes = aes,
-                        color = qplot_get_attribute(col, y),
+                        colour = qplot_get_attribute(col, y),
                         pch = qplot_get_attribute(pch, y),
                         lty = qplot_get_attribute(pch, y),
                         lwd = qplot_get_attribute(lwd, y))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ arphitgg(data, agg_aes(x = date), layout = "2b2") +
   agg_units("$", panel = "3") +
   agg_units("'000", panel = "4") +
   agg_shading(from = x4, to = x3) +
-  agg_label("A label", x = 2001.5, y = 1, panel = "1", color = "red") +
+  agg_label("A label", x = 2001.5, y = 1, panel = "1", colour = "red") +
   agg_abline(x = 2002, panel = "2") +
   agg_bgshading(y1 = -1, y2 = 3, panel = "4")
 ```

--- a/build-readme-images.R
+++ b/build-readme-images.R
@@ -25,7 +25,7 @@ p <- arphitgg(data, agg_aes(x = date), layout = "2b2") +
   agg_units("$", panel = "3") +
   agg_units("'000", panel = "4") +
   agg_shading(from = x4, to = x3) +
-  agg_label("A label", x = 2001.5, y = 1, panel = "1", color = "red") +
+  agg_label("A label", x = 2001.5, y = 1, panel = "1", colour = "red") +
   agg_abline(x = 2002, panel = "2") +
   agg_bgshading(y1 = -1, y2 = 3, panel = "4")
 agg_draw(p, filename = "complex_example.png")

--- a/man/agg_abline.Rd
+++ b/man/agg_abline.Rd
@@ -5,7 +5,7 @@
 \title{Add an AB line to your graph}
 \usage{
 agg_abline(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL,
-  y2 = NULL, color = "black", panel, lwd = 1, lty = 1)
+  y2 = NULL, colour = "black", color, panel, lwd = 1, lty = 1)
 }
 \arguments{
 \item{x}{Draw a vertical line at x (omit to draw a specific AB line)}
@@ -20,7 +20,9 @@ agg_abline(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL,
 
 \item{y2}{For specific AB lines: the second y coordinate}
 
-\item{color}{(optional) The color of the AB line (default black)}
+\item{colour}{The colour of the AB line (default black)}
+
+\item{color}{(Deprecated; use colour instead) The colour of the AB line (default black)}
 
 \item{panel}{Which panel should the line be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the line to multiple panels at once.}
 
@@ -32,12 +34,12 @@ agg_abline(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL,
 You need specify only one of x, or y, or x1,x2,y1,y2
 }
 \examples{
-arphitgg(data) + agg_abline(x = 2001, color = RBA["Blue1"], panel = "1") +
-  agg_abline(y = -0.5, color = RBA["Red1"], panel = "1")
+arphitgg(data) + agg_abline(x = 2001, colour = RBA["Blue1"], panel = "1") +
+  agg_abline(y = -0.5, colour = RBA["Red1"], panel = "1")
 
 arphitgg(data) +
   agg_abline(x1 = 2000, y1 = -0.1, x2 = 2002, y2 = 0.5,
-             color = RBA["Blue1"], panel = "1")
+             colour = RBA["Blue1"], panel = "1")
 
 }
 \seealso{

--- a/man/agg_abline.Rd
+++ b/man/agg_abline.Rd
@@ -5,7 +5,7 @@
 \title{Add an AB line to your graph}
 \usage{
 agg_abline(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL,
-  y2 = NULL, colour = "black", color, panel, lwd = 1, lty = 1)
+  y2 = NULL, colour = "black", panel, lwd = 1, lty = 1, color)
 }
 \arguments{
 \item{x}{Draw a vertical line at x (omit to draw a specific AB line)}
@@ -22,13 +22,13 @@ agg_abline(x = NULL, y = NULL, x1 = NULL, y1 = NULL, x2 = NULL,
 
 \item{colour}{The colour of the AB line (default black)}
 
-\item{color}{(Deprecated; use colour instead) The colour of the AB line (default black)}
-
 \item{panel}{Which panel should the line be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the line to multiple panels at once.}
 
 \item{lwd}{(Optional, default 1) The linewidth}
 
 \item{lty}{(Optional, default 1) The line type}
+
+\item{color}{(Deprecated; use colour instead) The colour of the AB line (default black)}
 }
 \description{
 You need specify only one of x, or y, or x1,x2,y1,y2

--- a/man/agg_arrow.Rd
+++ b/man/agg_arrow.Rd
@@ -4,8 +4,8 @@
 \alias{agg_arrow}
 \title{Add an arrow}
 \usage{
-agg_arrow(tail.x, tail.y, head.x, head.y, colour = "black", color, panel,
-  lwd = 1)
+agg_arrow(tail.x, tail.y, head.x, head.y, colour = "black", panel,
+  lwd = 1, color)
 }
 \arguments{
 \item{tail.x}{The x coordinate of the arrow tail}
@@ -18,11 +18,11 @@ agg_arrow(tail.x, tail.y, head.x, head.y, colour = "black", color, panel,
 
 \item{colour}{The colour of the arrow}
 
-\item{color}{(Deprecated; use colour instead) The colour of the arrow}
-
 \item{panel}{Which panel should the arrow be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the arrow to multiple panels at once.}
 
 \item{lwd}{(Optional, default 1) The linewidth of the arrow}
+
+\item{color}{(Deprecated; use colour instead) The colour of the arrow}
 }
 \description{
 Add an arrow

--- a/man/agg_arrow.Rd
+++ b/man/agg_arrow.Rd
@@ -4,7 +4,7 @@
 \alias{agg_arrow}
 \title{Add an arrow}
 \usage{
-agg_arrow(tail.x, tail.y, head.x, head.y, color = "black", panel,
+agg_arrow(tail.x, tail.y, head.x, head.y, colour = "black", color, panel,
   lwd = 1)
 }
 \arguments{
@@ -16,7 +16,9 @@ agg_arrow(tail.x, tail.y, head.x, head.y, color = "black", panel,
 
 \item{head.y}{The y coordinate of the arrow head}
 
-\item{color}{The color of the arrow}
+\item{colour}{The colour of the arrow}
+
+\item{color}{(Deprecated; use colour instead) The colour of the arrow}
 
 \item{panel}{Which panel should the arrow be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the arrow to multiple panels at once.}
 

--- a/man/agg_bgshading.Rd
+++ b/man/agg_bgshading.Rd
@@ -5,7 +5,7 @@
 \title{Add background shading}
 \usage{
 agg_bgshading(x1 = NA, y1 = NA, x2 = NA, y2 = NA,
-  colour = RBA["Grey2"], color, panel)
+  colour = RBA["Grey2"], panel, color)
 }
 \arguments{
 \item{x1}{The bottom left x coordinate (omit to have the shading automatically snap to the edge of the panel)}
@@ -18,9 +18,9 @@ agg_bgshading(x1 = NA, y1 = NA, x2 = NA, y2 = NA,
 
 \item{colour}{(optional) The colour of the AB line (default grey)}
 
-\item{color}{(Deprecated; use colour instead) The colour of the AB line (default grey)}
-
 \item{panel}{Which panel should the background shading be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the shading to multiple panels at once.}
+
+\item{color}{(Deprecated; use colour instead) The colour of the AB line (default grey)}
 }
 \description{
 Add background shading

--- a/man/agg_bgshading.Rd
+++ b/man/agg_bgshading.Rd
@@ -5,7 +5,7 @@
 \title{Add background shading}
 \usage{
 agg_bgshading(x1 = NA, y1 = NA, x2 = NA, y2 = NA,
-  color = RBA["Grey2"], panel)
+  colour = RBA["Grey2"], color, panel)
 }
 \arguments{
 \item{x1}{The bottom left x coordinate (omit to have the shading automatically snap to the edge of the panel)}
@@ -16,7 +16,9 @@ agg_bgshading(x1 = NA, y1 = NA, x2 = NA, y2 = NA,
 
 \item{y2}{The top right y coordinate (omit to have the shading automatically snap to the edge of the panel)}
 
-\item{color}{(optional) The color of the AB line (default grey)}
+\item{colour}{(optional) The colour of the AB line (default grey)}
+
+\item{color}{(Deprecated; use colour instead) The colour of the AB line (default grey)}
 
 \item{panel}{Which panel should the background shading be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the shading to multiple panels at once.}
 }

--- a/man/agg_col.Rd
+++ b/man/agg_col.Rd
@@ -4,15 +4,17 @@
 \alias{agg_col}
 \title{Add a col layer to an arphit plot.}
 \usage{
-agg_col(aes = NULL, data = NULL, color = NULL, barcol = NULL,
-  panel = "1", stacked = TRUE)
+agg_col(aes = NULL, data = NULL, colour = NULL, color,
+  barcol = NULL, panel = "1", stacked = TRUE)
 }
 \arguments{
 \item{aes}{The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.}
 
 \item{data}{The data to be used. Will inherit from parent if missing.}
 
-\item{color}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+\item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
 \item{barcol}{(optional) Outline colours for each bar series}
 

--- a/man/agg_col.Rd
+++ b/man/agg_col.Rd
@@ -4,8 +4,8 @@
 \alias{agg_col}
 \title{Add a col layer to an arphit plot.}
 \usage{
-agg_col(aes = NULL, data = NULL, colour = NULL, color,
-  barcol = NULL, panel = "1", stacked = TRUE)
+agg_col(aes = NULL, data = NULL, colour = NULL, barcol = NULL,
+  panel = "1", stacked = TRUE, color)
 }
 \arguments{
 \item{aes}{The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.}
@@ -14,13 +14,13 @@ agg_col(aes = NULL, data = NULL, colour = NULL, color,
 
 \item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
-\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
-
 \item{barcol}{(optional) Outline colours for each bar series}
 
 \item{panel}{(default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.}
 
 \item{stacked}{(default = TRUE) Stack the bars, or group them?}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 }
 \description{
 Add a col layer to an arphit plot.

--- a/man/agg_label.Rd
+++ b/man/agg_label.Rd
@@ -4,7 +4,7 @@
 \alias{agg_label}
 \title{Add a label}
 \usage{
-agg_label(text, x, y, panel, color = "black", size = 20)
+agg_label(text, x, y, panel, colour = "black", color, size = 20)
 }
 \arguments{
 \item{text}{The text to display on your plot}
@@ -15,7 +15,9 @@ agg_label(text, x, y, panel, color = "black", size = 20)
 
 \item{panel}{Which panel should the label be placed on? You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the label to multiple panels at once.}
 
-\item{color}{The color of your text}
+\item{colour}{The colour of your text}
+
+\item{color}{(Deprecated; use colour instead) The colour of your text}
 
 \item{size}{Font size (default 20)}
 }

--- a/man/agg_label.Rd
+++ b/man/agg_label.Rd
@@ -4,7 +4,7 @@
 \alias{agg_label}
 \title{Add a label}
 \usage{
-agg_label(text, x, y, panel, colour = "black", color, size = 20)
+agg_label(text, x, y, panel, colour = "black", size = 20, color)
 }
 \arguments{
 \item{text}{The text to display on your plot}
@@ -17,9 +17,9 @@ agg_label(text, x, y, panel, colour = "black", color, size = 20)
 
 \item{colour}{The colour of your text}
 
-\item{color}{(Deprecated; use colour instead) The colour of your text}
-
 \item{size}{Font size (default 20)}
+
+\item{color}{(Deprecated; use colour instead) The colour of your text}
 }
 \description{
 Add a label

--- a/man/agg_line.Rd
+++ b/man/agg_line.Rd
@@ -4,8 +4,8 @@
 \alias{agg_line}
 \title{Add a line layer to an arphit plot.}
 \usage{
-agg_line(aes = NULL, data = NULL, colour = NULL, color, pch = NULL,
-  lty = NULL, lwd = NULL, pointsize = 1, panel = "1")
+agg_line(aes = NULL, data = NULL, colour = NULL, pch = NULL,
+  lty = NULL, lwd = NULL, pointsize = 1, panel = "1", color)
 }
 \arguments{
 \item{aes}{The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.}
@@ -13,8 +13,6 @@ agg_line(aes = NULL, data = NULL, colour = NULL, color, pch = NULL,
 \item{data}{The data to be used. Will inherit from parent if missing.}
 
 \item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
-
-\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
 \item{pch}{A point marker to be applied to all series, or or (if your aesthetic has a group), a vector of pch values that will be cycled through to consecutive group elements. Any value accepted by R for pch can be used.}
 
@@ -25,6 +23,8 @@ agg_line(aes = NULL, data = NULL, colour = NULL, color, pch = NULL,
 \item{pointsize}{Scale the size of the points? (default 1)}
 
 \item{panel}{(default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 }
 \description{
 Add a line layer to an arphit plot.

--- a/man/agg_line.Rd
+++ b/man/agg_line.Rd
@@ -4,7 +4,7 @@
 \alias{agg_line}
 \title{Add a line layer to an arphit plot.}
 \usage{
-agg_line(aes = NULL, data = NULL, color = NULL, pch = NULL,
+agg_line(aes = NULL, data = NULL, colour = NULL, color, pch = NULL,
   lty = NULL, lwd = NULL, pointsize = 1, panel = "1")
 }
 \arguments{
@@ -12,7 +12,9 @@ agg_line(aes = NULL, data = NULL, color = NULL, pch = NULL,
 
 \item{data}{The data to be used. Will inherit from parent if missing.}
 
-\item{color}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+\item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
 \item{pch}{A point marker to be applied to all series, or or (if your aesthetic has a group), a vector of pch values that will be cycled through to consecutive group elements. Any value accepted by R for pch can be used.}
 

--- a/man/agg_point.Rd
+++ b/man/agg_point.Rd
@@ -4,8 +4,8 @@
 \alias{agg_point}
 \title{Add a scatter layer to an arphit plot.}
 \usage{
-agg_point(aes = NULL, data = NULL, colour = NULL, color,
-  pointsize = 1, panel = "1")
+agg_point(aes = NULL, data = NULL, colour = NULL, pointsize = 1,
+  panel = "1", color)
 }
 \arguments{
 \item{aes}{The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.}
@@ -14,11 +14,11 @@ agg_point(aes = NULL, data = NULL, colour = NULL, color,
 
 \item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
-\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
-
 \item{pointsize}{Scale the size of the points? (default 1)}
 
 \item{panel}{(default = "1") Which panel of the graph to place this layer on. You can specify a vector of panels (e.g. `panel = c("1","3")`) to apply the layer to multiple panels at once.}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 }
 \description{
 Add a scatter layer to an arphit plot.

--- a/man/agg_point.Rd
+++ b/man/agg_point.Rd
@@ -4,15 +4,17 @@
 \alias{agg_point}
 \title{Add a scatter layer to an arphit plot.}
 \usage{
-agg_point(aes = NULL, data = NULL, color = NULL, pointsize = 1,
-  panel = "1")
+agg_point(aes = NULL, data = NULL, colour = NULL, color,
+  pointsize = 1, panel = "1")
 }
 \arguments{
 \item{aes}{The aesthetic that defines the layer. Will inherit (or parts thereof) if omitted.}
 
 \item{data}{The data to be used. Will inherit from parent if missing.}
 
-\item{color}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+\item{colour}{A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
+
+\item{color}{(Deprecated; use colour instead) A colour to be applied to all of the series, or (if your aesthetic has a group), a vector of colours that will be cycled through to consecutive group elements.}
 
 \item{pointsize}{Scale the size of the points? (default 1)}
 

--- a/man/agg_shading.Rd
+++ b/man/agg_shading.Rd
@@ -4,7 +4,7 @@
 \alias{agg_shading}
 \title{Add shading between series}
 \usage{
-agg_shading(from, to, panel = NULL, color = RBA["Grey2"])
+agg_shading(from, to, panel = NULL, colour = RBA["Grey2"], color)
 }
 \arguments{
 \item{from}{The series name to shade from (if you have no group aesthetic, it will be the name of the y variable); if you have groups, it will (usually) be the group identifier. This can get more complicated if you have duplicate group names. If so, arphit appends .y to the group names, so try that.)}
@@ -13,7 +13,9 @@ agg_shading(from, to, panel = NULL, color = RBA["Grey2"])
 
 \item{panel}{(optional) Which panel are the relevant series in? (arphit will try to find them if you don't specify)}
 
-\item{color}{(optional) The color to shade between the series (default grey)}
+\item{colour}{(optional) The colour to shade between the series (default grey)}
+
+\item{color}{(Deprecated; use colour instead) The colour to shade between the series (default grey)}
 }
 \description{
 Add shading between series
@@ -21,8 +23,8 @@ Add shading between series
 \examples{
 data <- data.frame(date = seq.Date(from = as.Date("2000-03-10"), length.out = 12, by = "month"),
                    x1 = rnorm(12), x2 = rnorm(12))
-arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), color = RBA["Blue2"]) +
-   agg_line(agg_aes(y = x2), color = RBA["Red4"]) +
+arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), colour = RBA["Blue2"]) +
+   agg_line(agg_aes(y = x2), coluor = RBA["Red4"]) +
    agg_shading(from = x1, to = x2)
 
 }

--- a/tests/testthat/test-annotations.R
+++ b/tests/testthat/test-annotations.R
@@ -5,7 +5,7 @@ context("Annotations")
 # Labels
 test_that("Labels", {
   foo <- arphitgg() + agg_label("Text", x = 2002, y = 0.2, panel = "1", colour = "red")
-  bar <- arphitgg() + agg_label("Text", x = 2002, y = 0.2, panel = "1", colour = "red")
+  bar <- arphitgg() + agg_label("Text", x = 2002, y = 0.2, panel = "1", colour = "red") +
     agg_label("Second label", x = 2003, y = -0.2, panel = "1", colour = "green", size = 40)
   expect_true(check_graph(foo, "annotations-label1"))
   expect_true(check_graph(bar, "annotations-label2"))

--- a/tests/testthat/test-annotations.R
+++ b/tests/testthat/test-annotations.R
@@ -4,9 +4,9 @@ context("Annotations")
 
 # Labels
 test_that("Labels", {
-  foo <- arphitgg() + agg_label("Text", 2002, 0.2, "1", "red")
-  bar <- arphitgg() + agg_label("Text", 2002, 0.2, "1", "red") +
-    agg_label("Second label",2003, -0.2, "1", "green", 40)
+  foo <- arphitgg() + agg_label("Text", x = 2002, y = 0.2, panel = "1", colour = "red")
+  bar <- arphitgg() + agg_label("Text", x = 2002, y = 0.2, panel = "1", colour = "red")
+    agg_label("Second label", x = 2003, y = -0.2, panel = "1", colour = "green", size = 40)
   expect_true(check_graph(foo, "annotations-label1"))
   expect_true(check_graph(bar, "annotations-label2"))
 })
@@ -14,8 +14,9 @@ test_that("Labels", {
 ## Arrows ==================
 
 test_that("Arrows", {
-  foo <- arphitgg() + agg_arrow(2000, 0, 2001, 2, "red", "1")
-  bar <- arphitgg() + agg_arrow(2000, 0, 2001, 2, "red", "1") + agg_arrow(2001, 0, 2002, 2, "green", "1", 2)
+  foo <- arphitgg() + agg_arrow(tail.x = 2000, tail.y = 0, head.x = 2001, head.y = 2, colour = "red", panel = "1")
+  bar <- arphitgg() + agg_arrow(tail.x = 2000, tail.y = 0, head.x = 2001, head.y = 2, colour = "red", panel = "1") +
+    agg_arrow(tail.x = 2001, tail.y = 0, head.x = 2002, head.y = 2, colour = "green", panel = "1", lwd = 2)
   expect_true(check_graph(foo, "annotations-arrows1"))
   expect_true(check_graph(bar, "annotations-arrows2"))
 })
@@ -25,7 +26,7 @@ test_that("Arrows", {
 test_that("Background shading", {
   foo <- arphitgg() + agg_bgshading(x1 = 2001, x2 = 2002, panel = "1")
   bar <- arphitgg() + agg_bgshading(y1 = 0.5, y2 = -0.5, panel = "1")
-  baz <- arphitgg() + agg_bgshading(x1 = 2001, x2 = 2002, y1 = 0.5, y2 = -0.5, color = "red", panel = "1")
+  baz <- arphitgg() + agg_bgshading(x1 = 2001, x2 = 2002, y1 = 0.5, y2 = -0.5, colour = "red", panel = "1")
 
   expect_true(check_graph(foo, "annotations-bgshading1"))
   expect_true(check_graph(bar, "annotations-bgshading2"))
@@ -35,9 +36,9 @@ test_that("Background shading", {
 ## AB lines ================
 
 test_that("AB lines", {
-  foo <- arphitgg() + agg_abline(x = 2001, color = RBA["Blue1"], panel = "1")
-  bar <- arphitgg() + agg_abline(y = -0.5, color = RBA["Red1"], panel = "1") +
-    agg_abline(x = 2001, color = RBA["Blue1"], panel = "1")
+  foo <- arphitgg() + agg_abline(x = 2001, colour = RBA["Blue1"], panel = "1")
+  bar <- arphitgg() + agg_abline(y = -0.5, colour = RBA["Red1"], panel = "1") +
+    agg_abline(x = 2001, colour = RBA["Blue1"], panel = "1")
   baz <- arphitgg() + agg_abline(x1 = 2000, y1 = -0.1, x2 = 2002, y2 = 0.5, panel = "1")
   p <- arphitgg() + agg_abline(x = 2002, lty = 5, lwd = 20, panel = "1")
 
@@ -50,13 +51,13 @@ test_that("AB lines", {
 ## Extrapolating on missing arguments for ab lines ============
 
 test_that("Extrapolate ab lines arguments", {
-  expect_equal(agg_abline(x=2001,panel="1",color="green",lty=2),
+  expect_equal(agg_abline(x=2001,panel="1",colour="green",lty=2),
                  list(
                    x1 = 2001,
                    y1 = NA,
                    x2 = 2001,
                    y2 = NA,
-                   color = "green",
+                   colour = "green",
                    panel = "1",
                    lwd=1,
                    lty=2,
@@ -70,7 +71,7 @@ test_that("Extrapolate ab lines arguments", {
       y1 = -0.5,
       x2 = NA,
       y2 = -0.5,
-      color = "black",
+      colour = "black",
       panel = "1",
       lwd = 1,
       lty = 1,
@@ -83,7 +84,7 @@ test_that("Extrapolate ab lines arguments", {
       y1 = -1,
       x2 = 2001,
       y2 = 0,
-      color = "black",
+      colour = "black",
       panel = "1",
       lwd = 1,
       lty = 1,

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -12,12 +12,12 @@ test_that("Default attributes", {
 test_that("Setting attributes", {
   # Set different attributes for each series
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=y), color = "red",
+    agg_line(agg_aes(y=y), colour = "red",
              pch = 1,
              lty = 3,
              lwd = 5,
              pointsize = 9) +
-    agg_line(agg_aes(y=y2), color = "green",
+    agg_line(agg_aes(y=y2), colour = "green",
              pch = 2,
              lty = 4,
              lwd = 6,
@@ -26,13 +26,13 @@ test_that("Setting attributes", {
 
   # Bar attributes
   p <- arphitgg(data, agg_aes(x=x,y=y)) +
-    agg_col(color = "blue",
+    agg_col(colour = "blue",
             barcol = "red")
   expect_true(check_graph(p, "attributes-bars"))
 
   # Set only one series attributes
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=y), color = "red",
+    agg_line(agg_aes(y=y), colour = "red",
              pch = 1,
              lty = 3,
              lwd = 5,
@@ -42,13 +42,13 @@ test_that("Setting attributes", {
 
   ## Two sided
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=y), color = "red",
+    agg_line(agg_aes(y=y), colour = "red",
              pch = 1,
              lty = 3,
              lwd = 5,
              pointsize = 9,
              panel = "1") +
-    agg_line(agg_aes(y=y2), color = "green",
+    agg_line(agg_aes(y=y2), colour = "green",
              pch = 2,
              lty = 4,
              lwd = 6,
@@ -61,13 +61,13 @@ test_that("Setting attributes", {
 test_that("Duplicate series names", {
   ## Duplicates
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=y), color = "red",
+    agg_line(agg_aes(y=y), colour = "red",
              pch = 1,
              lty = 3,
              lwd = 5,
              pointsize = 9,
              panel = "1") +
-    agg_line(agg_aes(y=y), color = "green",
+    agg_line(agg_aes(y=y), colour = "green",
              pch = 2,
              lty = 4,
              lwd = 6,
@@ -79,12 +79,12 @@ test_that("Duplicate series names", {
 
 test_that("Setting user default colours", {
   # Setting user colours (#176, which changed to using R's options, instead of my earlier awful hack)
-  options(arphit.user_colors = c(RBA["Red1"],RBA["Blue10"],RBA["Olive1"]))
+  options(arphit.user_colours = c(RBA["Red1"],RBA["Blue10"],RBA["Olive1"]))
   p <- arphitgg(data)+agg_line(agg_aes(x=x,y=y))+agg_line(agg_aes(x=x,y=y2))
   expect_true(check_graph(p, "attributes-changed-defaults"))
 
   # And change back
-  options(arphit.user_colors = NULL)
+  options(arphit.user_colours = NULL)
   p <- arphitgg(data)+agg_line(agg_aes(x=x,y=y))+agg_line(agg_aes(x=x,y=y2))
   expect_true(check_graph(p, "attributes-reverted-defaults"))
 

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -89,8 +89,8 @@ test_that("Simple labels", {
   foo <- tibble::tibble(year = 2000:2020, y = 1:21)
   foo2 <- tibble::tibble(year = 2000:2020, y = 2:22)
   p <- arphitgg(aes = agg_aes(x=year,y=y), layout = "1", showallxlabels = FALSE) +
-    agg_line(data = foo, panel = "1", color = "red") +
-    agg_line(data = foo2, panel = "1", color = "red") +
+    agg_line(data = foo, panel = "1", colour = "red") +
+    agg_line(data = foo2, panel = "1", colour = "red") +
     agg_autolabel(TRUE)
   expect_true(check_graph(p, "autolabel-same-series-one-panel", 0.985))
 })
@@ -224,7 +224,7 @@ test_that("Which panels should be autolabelled", {
     agg_line(agg_aes(y=b), panel = "1") +
     agg_line(agg_aes(y=b), panel = "2") +
     agg_line(agg_aes(y=c), panel = "2") +
-    agg_label("Test",x=2,y=4,color="black",panel="1") +
+    agg_label("Test",x=2,y=4,colour="black",panel="1") +
     agg_autolabel(TRUE)
   expect_true(
     check_graph(p, "autolabel-one-panel-labelled")

--- a/tests/testthat/test-draw-outer.R
+++ b/tests/testthat/test-draw-outer.R
@@ -7,42 +7,42 @@ data <- data.frame(x=1:10,a=1:10,b=11:20,c=21:30,d=31:40)
 test_that("Legend series and colours", {
   # basic legend tests over one panel, with left and right axes
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=a), panel = "1", color = "red") +
-    agg_line(agg_aes(y=b), panel = "1", color = "green") +
+    agg_line(agg_aes(y=a), panel = "1", colour = "red") +
+    agg_line(agg_aes(y=b), panel = "1", colour = "green") +
     agg_legend()
   expect_true(check_graph(p, "draw-outer-basic-legend"))
 
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=a), panel = "1", color = "red") +
-    agg_line(agg_aes(y=b), panel = "1", color = "green") +
-    agg_line(agg_aes(y=c), panel = "2", color = "blue") +
-    agg_line(agg_aes(y=d), panel = "2", color = "yellow") +
+    agg_line(agg_aes(y=a), panel = "1", colour = "red") +
+    agg_line(agg_aes(y=b), panel = "1", colour = "green") +
+    agg_line(agg_aes(y=c), panel = "2", colour = "blue") +
+    agg_line(agg_aes(y=d), panel = "2", colour = "yellow") +
     agg_legend()
   expect_true(check_graph(p, "draw-outer-basic-legend-lhs-rhs"))
 
   # check pch works too
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=a), panel = "1", color = "red", pch = 20) +
-    agg_line(agg_aes(y=b), panel = "1", color = "green") +
+    agg_line(agg_aes(y=a), panel = "1", colour = "red", pch = 20) +
+    agg_line(agg_aes(y=b), panel = "1", colour = "green") +
     agg_legend()
   expect_true(check_graph(p, "draw-outer-pch"))
 
   # tests for duplicate series names
   # same attributes for duplicate
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=a), panel = "1", color = "red") +
-    agg_line(agg_aes(y=b), panel = "1", color = "green") +
-    agg_line(agg_aes(y=a), panel = "2", color = "red") +
-    agg_line(agg_aes(y=d), panel = "2", color = "yellow") +
+    agg_line(agg_aes(y=a), panel = "1", colour = "red") +
+    agg_line(agg_aes(y=b), panel = "1", colour = "green") +
+    agg_line(agg_aes(y=a), panel = "2", colour = "red") +
+    agg_line(agg_aes(y=d), panel = "2", colour = "yellow") +
     agg_legend()
   expect_true(check_graph(p, "draw-outer-basic-duplicate-names-same-attributes"))
 
   # different attributes for duplicate
   p <- arphitgg(data, agg_aes(x=x)) +
-    agg_line(agg_aes(y=a), panel = "1", color = "red") +
-    agg_line(agg_aes(y=b), panel = "1", color = "green") +
-    agg_line(agg_aes(y=a), panel = "2", color = "blue") +
-    agg_line(agg_aes(y=d), panel = "2", color = "yellow") +
+    agg_line(agg_aes(y=a), panel = "1", colour = "red") +
+    agg_line(agg_aes(y=b), panel = "1", colour = "green") +
+    agg_line(agg_aes(y=a), panel = "2", colour = "blue") +
+    agg_line(agg_aes(y=d), panel = "2", colour = "yellow") +
     agg_legend()
   expect_true(check_graph(p, "draw-outer-basic-duplicate-names"))
 })

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -318,10 +318,10 @@ test_that("Mutiple panel constructors", {
   expect_equal(p1, p2)
 
   # label
-  p1 <- arphitgg() + agg_label("Foo", x = 2000, y = 1, color = "black", panel = c("1", "2"))
+  p1 <- arphitgg() + agg_label("Foo", x = 2000, y = 1, colour = "black", panel = c("1", "2"))
   p2 <- arphitgg() +
-    agg_label("Foo", x = 2000, y = 1, color = "black", panel = "1") +
-    agg_label("Foo", x = 2000, y = 1, color = "black", panel = "2")
+    agg_label("Foo", x = 2000, y = 1, colour = "black", panel = "1") +
+    agg_label("Foo", x = 2000, y = 1, colour = "black", panel = "2")
   expect_equal(p1, p2)
 
   # arrow
@@ -331,9 +331,9 @@ test_that("Mutiple panel constructors", {
   expect_equal(p1, p2)
 
   # abline
-  p1 <- arphitgg() + agg_abline(1,color="black",panel=c("1","2"))
-  p2 <- arphitgg() + agg_abline(1,color="black",panel="1") +
-    agg_abline(1,color="black",panel="2")
+  p1 <- arphitgg() + agg_abline(1,colour="black",panel=c("1","2"))
+  p2 <- arphitgg() + agg_abline(1,colour="black",panel="1") +
+    agg_abline(1,colour="black",panel="2")
   expect_equal(p1, p2)
 
   # bgshading
@@ -407,6 +407,6 @@ test_that("Miscellaneous", {
   foo <- data.frame(x=1:10,y=3,g=1:10)
   foo$g[4] <- NA
   p <- arphitgg(foo, agg_aes(x=x,y=y,group=g)) +
-    agg_col(color = c(RBA["Aqua8"], RBA["Aqua8"], RBA["Grey7"], RBA["Orange2"], RBA["DarkGreen7"], RBA["Violet1"], RBA["Blue7"], RBA["Red5"], RBA["Brown4"], RBA["Pink2"]))
+    agg_col(colour = c(RBA["Aqua8"], RBA["Aqua8"], RBA["Grey7"], RBA["Orange2"], RBA["DarkGreen7"], RBA["Violet1"], RBA["Blue7"], RBA["Red5"], RBA["Brown4"], RBA["Pink2"]))
   expect_true(check_graph(p, "gg-na-in-group"))
 })

--- a/tests/testthat/test-zzz-deprecations.R
+++ b/tests/testthat/test-zzz-deprecations.R
@@ -1,0 +1,53 @@
+context("Deprecation warnings")
+
+test_that("Deprecation warnings for color", {
+  data <- data.frame(x=1:10,y=1:10)
+  expect_warning(
+    arphitgg(data) + agg_line(agg_aes(x=x,y=y),color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg(data) + agg_col(agg_aes(x=x,y=y),color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg(data) + agg_point(agg_aes(x=x,y=y),color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg() + agg_label(x=1,y=2,text="a",panel="1",color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg() + agg_arrow(tail.x=1,tail.y=2,head.x=1,head.y=3,panel="1",color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg() + agg_abline(x=4,panel="1",color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  expect_warning(
+    arphitgg() + agg_bgshading(x1=1,y1=2,x2=2,y2=3,panel="1",color="red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+
+  data <- data.frame(x=1:10,y=2:11,z=3:12)
+  expect_warning(
+    arphitgg(data) + agg_line(agg_aes(x=x,y=y)) + agg_line(agg_aes(x=x,y=z)) + agg_shading(from = z, to = y, color = "red"),
+    "color is deprecated; use colour instead",
+    fixed = TRUE
+  )
+})

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -188,26 +188,26 @@ knitr::include_graphics("inherit.png")
 Specifying line, bar or point (depending on layer type) colours for series is done when creating a layer. For instance:
 ```{r, results = "hide"}
 p <- arphitgg() + 
-  agg_line(data = simple_data, aes = agg_aes(x = date, y = y), color = RBA["Red1"])
+  agg_line(data = simple_data, aes = agg_aes(x = date, y = y), colour = RBA["Red1"])
 ``````{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "simplecolor.png")
+agg_draw(p, filename = "simplecolour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("simplecolor.png")
+knitr::include_graphics("simplecolour.png")
 ```
 
-This color is applied to _all_ series in the layer. This is less helpful when you have a group variable, since they will all show up as the same colour (which is unlikely to be what you want). E.g. this is not helpful:
+This colour is applied to _all_ series in the layer. This is less helpful when you have a group variable, since they will all show up as the same colour (which is unlikely to be what you want). E.g. this is not helpful:
 ```{r, results = "hide"}
 p <- arphitgg() +
   agg_line(data = long_data,
            aes = agg_aes(x = date, y = y, group = state),
-           color = RBA["Red1"])
+           colour = RBA["Red1"])
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "group-single-color.png")
+agg_draw(p, filename = "group-single-colour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("group-single-color.png")
+knitr::include_graphics("group-single-colour.png")
 ```
 
 To specify for different colours for different series in a grouped layer, you can instead specify a _vector_ of colours:
@@ -215,13 +215,13 @@ To specify for different colours for different series in a grouped layer, you ca
 p <- arphitgg() +
   agg_line(data = long_data,
            aes = agg_aes(x = date, y = y, group = state),
-           color = c(RBA["Red1"], RBA["Blue4"]))
+           colour = c(RBA["Red1"], RBA["Blue4"]))
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "group-multi-color.png")
+agg_draw(p, filename = "group-multi-colour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("group-multi-color.png")
+knitr::include_graphics("group-multi-colour.png")
 ```
 
 (NB: `arphit` will cycle through the supplied vector colours if there aren't enough in the vector to cover the number of series in the layer.)
@@ -232,7 +232,7 @@ Alternatively, you can use any colour that R recognises.
 
 ## Other attributes
 
-You can control line type, line width and points markers with `lty`, `lwd` and `pch`. These work just like `color`. See the [plotting options guide](plotting-options.html) for more detail.
+You can control line type, line width and points markers with `lty`, `lwd` and `pch`. These work just like `colour`. See the [plotting options guide](plotting-options.html) for more detail.
 
 # Titles
 

--- a/vignettes/index.Rmd
+++ b/vignettes/index.Rmd
@@ -46,7 +46,7 @@ arphitgg(data, agg_aes(x = date), layout = "2b2") +
   agg_units("$", panel = "3") +
   agg_units("'000", panel = "4") +
   agg_shading(from = x4, to = x3) +
-  agg_label("A label", x = 2001.5, y = 1, panel = "1", color = "red") +
+  agg_label("A label", x = 2001.5, y = 1, panel = "1", colour = "red") +
   agg_abline(x = 2002, panel = "2") +
   agg_bgshading(y1 = -1, y2 = 3, panel = "4")
 ```
@@ -176,7 +176,7 @@ p <- arphitgg(data, agg_aes(x = date), layout = "2b2") +
   agg_units("$", panel = "3") +
   agg_units("'000", panel = "4") +
   agg_shading(from = x4, to = x3) +
-  agg_label("A label", x = 2001.5, y = 1, panel = "1", color = "red") +
+  agg_label("A label", x = 2001.5, y = 1, panel = "1", colour = "red") +
   agg_abline(x = 2002, panel = "2") +
   agg_bgshading(y1 = -1, y2 = 3, panel = "4")
 agg_draw(p, filename = "complex_example.png")

--- a/vignettes/plotting-options.Rmd
+++ b/vignettes/plotting-options.Rmd
@@ -483,7 +483,7 @@ There are 7 options for line layers. What the options do is covered in more deta
 
 * The dataset to be drawn (`data`)
 * The aesthetic that defines how to turn the data into a graph (`aes`)
-* The colour (or colours) for the series (`color`)
+* The colour (or colours) for the series (`colour`)
 * Point markers for the series (`pch`)
 * The line type - e.g. solid or dashed - for the sereis (`lty`)
 * The linewidth of the lines (`lwd`)
@@ -496,7 +496,7 @@ There are 7 options for line layers. What the options do is covered in more deta
 
 * The aesthetic that defines how to turn the data into a graph (`aes`)
 * The dataset to be drawn (`data`)
-* The colour (or colours) for the series (`color`)
+* The colour (or colours) for the series (`colour`)
 * The colour for the outline of the bars (`barcol`)
 * Which panel to plot the series on (`panel`). This is ignored if the aesthetic defines a facet variable.
 * Whether the bars should be stacked (default) or grouped (`stacked`). This is a global option; you cannot combine stacked and grouped layers.
@@ -505,7 +505,7 @@ There are 7 options for line layers. What the options do is covered in more deta
 
 `agg_point` layers are just a wrapper around `agg_line` that set the line to NA, and the point marker (`pch`) to `19` for solid dots. Naturally, this layer type is best for scatter graphs, as they quicker and easier than constructing your own `agg_line` layer.
 
-`agg_point` has only 5 options Data (`data`), aesthetic (`aes`), panel (`panel`), colour for the markers (`color`) and a size for the points (`pointsize`). As with other layer types, data and aesthetic (including parts of an aesthetic) will be inherited from the parent if omitted.
+`agg_point` has only 5 options Data (`data`), aesthetic (`aes`), panel (`panel`), colour for the markers (`colour`) and a size for the points (`pointsize`). As with other layer types, data and aesthetic (including parts of an aesthetic) will be inherited from the parent if omitted.
 
 # Series colours and other attributes
 
@@ -514,27 +514,27 @@ There are 7 options for line layers. What the options do is covered in more deta
 Specifying line, bar or point (depending on layer type) colours for series is done when creating a layer. For instance:
 ```{r, results = "hide"}
 p <- arphitgg() + 
-  agg_line(data = simple_data, aes = agg_aes(x = date, y = y1), color = RBA["Red1"])
+  agg_line(data = simple_data, aes = agg_aes(x = date, y = y1), colour = RBA["Red1"])
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "simplecolor.png")
+agg_draw(p, filename = "simplecolour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("simplecolor.png")
+knitr::include_graphics("simplecolour.png")
 ```
 
-This color is applied to _all_ series in the layer. This is less helpful when you have a group variable, since they will all show up as the same colour (which is unlikely to be what you want). E.g. this is not helpful:
+This colour is applied to _all_ series in the layer. This is less helpful when you have a group variable, since they will all show up as the same colour (which is unlikely to be what you want). E.g. this is not helpful:
 ```{r, results = "hide"}
 p <- arphitgg() +
   agg_line(data = long_data,
            aes = agg_aes(x = date, y = y1, group = group_var),
-           color = RBA["Red1"])
+           colour = RBA["Red1"])
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "group-single-color.png")
+agg_draw(p, filename = "group-single-colour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("group-single-color.png")
+knitr::include_graphics("group-single-colour.png")
 ```
 
 To specify for different colours for different series in a grouped layer, you can instead specify a _vector_ of colours:
@@ -542,13 +542,13 @@ To specify for different colours for different series in a grouped layer, you ca
 p <- arphitgg() +
   agg_line(data = long_data,
            aes = agg_aes(x = date, y = y1, group = group_var),
-           color = c(RBA["Red1"], RBA["Blue4"]))
+           colour = c(RBA["Red1"], RBA["Blue4"]))
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
-agg_draw(p, filename = "group-multi-color.png")
+agg_draw(p, filename = "group-multi-colour.png")
 ```
 ```{r, out.width = "50%", echo = FALSE, fig.align="center"}
-knitr::include_graphics("group-multi-color.png")
+knitr::include_graphics("group-multi-colour.png")
 ```
 
 (NB: `arphit` will cycle through the supplied vector colours if there aren't enough in the vector to cover the number of series in the layer.)
@@ -557,13 +557,13 @@ To see the full list of availble colours type `vignette("rba-colours", package =
 
 Alternatively, you can use any colour that R recognises.
 
-If you don't specify colours, arphit cycles through a set of default colours. Should you need to (e.g. for labels) you can access the default colors using the alias `RBA["Default1"]` etc.
+If you don't specify colours, arphit cycles through a set of default colours. Should you need to (e.g. for labels) you can access the default colours using the alias `RBA["Default1"]` etc.
 
-### (Advanced) Defining your own default colors
+### (Advanced) Defining your own default colours
 
-If you want to define your own set of default colors to be used set the option `arphit.user_colors` with a vector of colours. Putting this into your `.Rprofile` is sensible.
+If you want to define your own set of default colours to be used set the option `arphit.user_colours` with a vector of colours. Putting this into your `.Rprofile` is sensible.
 ```{r, eval=FALSE}
-options(arphit.user_colors = c(RBA["Red1"],RBA["Blue10"],RBA["Olive1"]))
+options(arphit.user_colours = c(RBA["Red1"],RBA["Blue10"],RBA["Olive1"]))
 ```
 
 ## Line markers
@@ -927,7 +927,7 @@ Shading is drawn in the order you add it; the first shading added is on the bott
 p <- arphitgg(simple_data, agg_aes(x=date)) +
   agg_line(agg_aes(y=y1)) +
   agg_line(agg_aes(y=y2)) +
-  agg_shading(from = y1, to = y2, color = RBA["Blue1"])
+  agg_shading(from = y1, to = y2, colour = RBA["Blue1"])
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "shading-single.png")
@@ -943,8 +943,8 @@ p <- arphitgg(simple_data, agg_aes(x=date)) +
   agg_line(agg_aes(y=y2)) +
   agg_line(agg_aes(y=y3)) +
   agg_line(agg_aes(y=y4)) +
-  agg_shading(from = y1, to = y2, color = RBA["Blue1"]) + 
-  agg_shading(from = y3, to = y4, color = "lightgrey")
+  agg_shading(from = y1, to = y2, colour = RBA["Blue1"]) + 
+  agg_shading(from = y3, to = y4, colour = "lightgrey")
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "shading-multiple.png")
@@ -964,12 +964,12 @@ You can add series labels, and arrows to aid those labels, using `agg_label` and
 * `text` is the label text. You can add line breaks in text using the `\n` character.
 * `x` and `y` specify where (in the units on the plot) the centre of the label should be. For time series, `x` is in decimal years (i.e. 2000.5 is July 2, 2000). For categorical graphs, 1 corresponds to the first categories, 2 to the second, etc.
 * `panel` specifies which panel to place the label on.
-* `color` is self-explanatory; if not specified, defaults to black.
+* `colour` is self-explanatory; if not specified, defaults to black.
 * `size` is optional and sets the font size. The default is 20.
  
 ```{r, results = "hide"}
 p <- arphitgg() +
-  agg_label("A label", x = 2002, y = 0.5, color = RBA["Blue2"], panel = "1")
+  agg_label("A label", x = 2002, y = 0.5, colour = RBA["Blue2"], panel = "1")
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "labels.png")
@@ -983,12 +983,12 @@ Arrows are specified with `agg_arrow`.
 * `tail.x` and `tail.y` specify the coordinates (in the units on the plot) of where to start the arrow at.
 * `head.x` and `head.y` where to finish the arrow (and where the arrow head is).
 * `panel` specifies which panel to place the arrow on.
-* `color` is self-explanatory.
+* `colour` is self-explanatory.
 * `lwd` is optional and specifies the linewidth of the arrow (default = 1).
  
 ```{r, results = "hide"}
 p <- arphitgg() +
-  agg_arrow(tail.x = 2000, tail.y = 0, head.x = 2001, head.y = 0.5, color = RBA["Blue1"], panel = "1")
+  agg_arrow(tail.x = 2000, tail.y = 0, head.x = 2001, head.y = 0.5, colour = RBA["Blue1"], panel = "1")
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "arrow.png")
@@ -1054,13 +1054,13 @@ knitr::include_graphics("autolabel_rhs.png")
 
 ## Adding horizonal and vertical lines
 
-Horizontal and vertical lines are added using `agg_abline`. Horizontal lines are drawn by specifying the `y` variable _only; vertical the `x` variable only. You can also control the color and line type. These are optional and default to a solid black line. You must also tell `arphit` which panel to put the line on.
+Horizontal and vertical lines are added using `agg_abline`. Horizontal lines are drawn by specifying the `y` variable _only; vertical the `x` variable only. You can also control the colour and line type. These are optional and default to a solid black line. You must also tell `arphit` which panel to put the line on.
 
-The following example draws a vertical line at 2001 using the default colour and solid line. It also draws a horizontal line at -1 colored darkred and dashed (`lty = 2`).
+The following example draws a vertical line at 2001 using the default colour and solid line. It also draws a horizontal line at -1 coloured darkred and dashed (`lty = 2`).
 ```{r, results = "hide"}
 p <- arphitgg() + 
   agg_abline(x = 2001, panel = "1") + 
-  agg_abline(y = -1, color = "darkred", lty = 2, panel = "1")
+  agg_abline(y = -1, colour = "darkred", lty = 2, panel = "1")
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "lines.png")
@@ -1085,7 +1085,7 @@ Entering NA (or omitting the argument) for any of `x1`, `y1`, `x2`, or `y2` will
 
 ## Adding background shading
 
-Background shading can be added using `agg_bgshading`. This draws a rectangle with bottom left corner at `x1`, `y1` and top right corner at `x2`,`y2`. Passing NA for any of the four coordinates will set that coordinate to the axis limit - this is useful for creating shading that stretches across a whole panel. `color` and `panel` are self-explanatory (color is optional and defaults to light grey).
+Background shading can be added using `agg_bgshading`. This draws a rectangle with bottom left corner at `x1`, `y1` and top right corner at `x2`,`y2`. Passing NA for any of the four coordinates will set that coordinate to the axis limit - this is useful for creating shading that stretches across a whole panel. `colour` and `panel` are self-explanatory (colour is optional and defaults to light grey).
 
 This example creates horizontal shading across the whole panel between -1 and 3 on the y axis.
 ```{r, results = "hide"}
@@ -1103,7 +1103,7 @@ And this two panel example repeats the above example for panel 1, but puts light
 ```{r, results = "hide"}
 p <- arphitgg(layout = "2h") + 
   agg_bgshading(x1 = NA, y1 = -0.5, x2 = NA, y2 = 0.5, panel = "1") + 
-  agg_bgshading(x1 = 2000.5, y1 = NA, x2 = 2001.5, y2 = NA, panel = "3", color = "lightgreen")
+  agg_bgshading(x1 = 2000.5, y1 = NA, x2 = 2001.5, y2 = NA, panel = "3", colour = "lightgreen")
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
 agg_draw(p, filename = "bgshading2.png")

--- a/vignettes/qplot-options.Rmd
+++ b/vignettes/qplot-options.Rmd
@@ -274,7 +274,7 @@ knitr::include_graphics("setattributeall.png")
 
 `col` controls the colour of your series. If a colour is not specified for a series, `arphit` cycles through default colours.
 
-The color palette can be accessed using `RBA["Green1"]` etc. For instance:
+The colour palette can be accessed using `RBA["Green1"]` etc. For instance:
 ```{r, eval = FALSE}
 agg_qplot(data,
           series = c("x2", "x4"),

--- a/vignettes/rba-colours.Rmd
+++ b/vignettes/rba-colours.Rmd
@@ -36,7 +36,7 @@ for (i in 1:10) {
   text(i, x = xoff, y = 6/5 - 0.025)
 }
 
-# Draw each of the colors and boxes
+# Draw each of the colourss and boxes
 yoff <- 6/5 - 0.02
 for (col in colours) {
   yoff <- yoff - 0.08


### PR DESCRIPTION
The package was very inconsistent in its use of Australian spelling. For consistency, and ease of remembering, stick to colour everywhere. Add deprecation warnings for any use of `color`.

Closes #283 