### PR TITLE
Fix up vignette and examples for color deprecation

### DIFF
--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -319,7 +319,7 @@ agg_bgshading <- function(x1 = NA, y1 = NA, x2 = NA, y2 = NA, colour = RBA["Grey
 #' data <- data.frame(date = seq.Date(from = as.Date("2000-03-10"), length.out = 12, by = "month"),
 #'                    x1 = rnorm(12), x2 = rnorm(12))
 #' arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), colour = RBA["Blue2"]) +
-#'    agg_line(agg_aes(y = x2), coluor = RBA["Red4"]) +
+#'    agg_line(agg_aes(y = x2), colour = RBA["Red4"]) +
 #'    agg_shading(from = x1, to = x2)
 #'
 #' @export

--- a/man/agg_shading.Rd
+++ b/man/agg_shading.Rd
@@ -24,7 +24,7 @@ Add shading between series
 data <- data.frame(date = seq.Date(from = as.Date("2000-03-10"), length.out = 12, by = "month"),
                    x1 = rnorm(12), x2 = rnorm(12))
 arphitgg(data, agg_aes(x = date)) + agg_line(agg_aes(y = x1), colour = RBA["Blue2"]) +
-   agg_line(agg_aes(y = x2), coluor = RBA["Red4"]) +
+   agg_line(agg_aes(y = x2), colour = RBA["Red4"]) +
    agg_shading(from = x1, to = x2)
 
 }

--- a/vignettes/plotting-options.Rmd
+++ b/vignettes/plotting-options.Rmd
@@ -1028,7 +1028,7 @@ If you put text labels on a panel, that disables the auto labeller for that pane
 p <- arphitgg(long_data, agg_aes(x = date, y = y1, group = group_var), layout = "2v") +
   agg_line(panel = "1") + 
   agg_line(panel = "2") + 
-  agg_label("Manual\nlabel disables\nautolabels", x = 2001, y = 1.5, col = "black", panel = "2") + 
+  agg_label("Manual\nlabel disables\nautolabels", x = 2001, y = 1.5, colour = "black", panel = "2") + 
   agg_autolabel()
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}
@@ -1042,7 +1042,7 @@ The autolabeller should correctly handle left and right hand series:
 ```{r, results = "hide"}
 p <- arphitgg(simple_data, agg_aes(x = date), layout = "1") +
   agg_line(agg_aes(y = y1), panel = "1") + 
-  agg_line(agg_aes(y = y2), col = RBA["Orange5"], panel = "2") + 
+  agg_line(agg_aes(y = y2), colour = RBA["Orange5"], panel = "2") + 
   agg_autolabel()
 ```
 ```{r, echo = FALSE, results = "hide", warning = FALSE, message = FALSE}


### PR DESCRIPTION
These got missed in the update to colour instead of color. It should have been picked up by CI, but Travis seems a bit broken at the moment.