### PR TITLE
Improve handling of NAs in groups

### DIFF
--- a/R/gg-add-layers.R
+++ b/R/gg-add-layers.R
@@ -126,9 +126,9 @@ assign_series <- function(gg, data, aes, panel, bar) {
     gg$data[[panel]]$series <- append(gg$data[[panel]]$series, list(new_series))
   } else {
     # Special case NAs in the data
-    groups <- as.character(rlang::eval_tidy(aes$group, data))
-    groups[is.na(groups)] <- "<NA>"
+    groups <- factor(rlang::eval_tidy(aes$group, data), ordered = FALSE, exclude = NULL)
     data <- split(data, groups)
+    names(data)[is.na(names(data))] <- "<NA>"
 
     for (name in names(data)) {
       new_series <- create_series(name, rlang::eval_tidy(aes$x, data[[name]]), rlang::eval_tidy(aes$y, data[[name]]), bar)

--- a/tests/testthat/test-gg.R
+++ b/tests/testthat/test-gg.R
@@ -407,6 +407,6 @@ test_that("Miscellaneous", {
   foo <- data.frame(x=1:10,y=3,g=1:10)
   foo$g[4] <- NA
   p <- arphitgg(foo, agg_aes(x=x,y=y,group=g)) +
-    agg_col(colour = c(RBA["Aqua8"], RBA["Aqua8"], RBA["Grey7"], RBA["Orange2"], RBA["DarkGreen7"], RBA["Violet1"], RBA["Blue7"], RBA["Red5"], RBA["Brown4"], RBA["Pink2"]))
+    agg_col()
   expect_true(check_graph(p, "gg-na-in-group"))
 })


### PR DESCRIPTION
Split converts the splitting variable to a factor. I can more elegantly handle NAs by explicitly converting to a factor first and specifying _not_ to drop NAs.