### PR TITLE
Modernise some old tests

### DIFF
--- a/tests/testthat/test-axes.R
+++ b/tests/testthat/test-axes.R
@@ -162,10 +162,10 @@ test_that("Default scale", {
     # Just do this 100 times to get lots of different scales and check they are all fine
     data <- data.frame(y=rnorm(10))
     scale <- defaultscale(max(data), min(data))
-    expect_that(scale$min <= min(data),is_true())
-    expect_that(scale$max >= max(data),is_true())
-    expect_that(scale$nsteps <= max(PERMITTEDSTEPS),is_true())
-    expect_that(scale$nsteps >= min(PERMITTEDSTEPS),is_true())
+    expect_true(scale$min <= min(data))
+    expect_true(scale$max >= max(data))
+    expect_true(scale$nsteps <= max(PERMITTEDSTEPS))
+    expect_true(scale$nsteps >= min(PERMITTEDSTEPS))
   }
 
   # Check that default scales are sensible for stacked _bar_ series (#147)

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -16,11 +16,11 @@ data <-
 
 ## Tests for types of data
 test_that("Acceptable data types", {
-  expect_that(is.acceptable.data(data.frame(x1 = 1:10)), is_true())
-  expect_that(is.acceptable.data(tibble::tibble(x1 = 1:10)), is_true())
-  expect_that(is.acceptable.data(utils::data), is_false())
-  expect_that(is.acceptable.data(1), is_false())
-  expect_that(is.acceptable.data(utils::data()), is_false())
+  expect_true(is.acceptable.data(data.frame(x1 = 1:10)))
+  expect_true(is.acceptable.data(tibble::tibble(x1 = 1:10)))
+  expect_false(is.acceptable.data(utils::data))
+  expect_false(is.acceptable.data(1))
+  expect_false(is.acceptable.data(utils::data()))
 })
 
 ## Errors ==================

--- a/tests/testthat/test-draw-figure.R
+++ b/tests/testthat/test-draw-figure.R
@@ -8,14 +8,14 @@ test_that("Filetypes", {
     file <- paste("foo.", suffix, sep = "")
     agg_qplot(randomdata, filename = file)
     # test exists
-    expect_that(file.exists(file), is_true())
+    expect_true(file.exists(file))
     # remove
     file.remove(file)
   }
 
   # Special case EMF+, because we change the file extension
   agg_qplot(randomdata, filename = "foo.emf+")
-  expect_that(file.exists("foo.emf"), is_true())
+  expect_true(file.exists("foo.emf"))
   file.remove("foo.emf")
 
   p <- arphitgg()


### PR DESCRIPTION
Were relying on now-deprecated parts of testthat. Update to modern versions.