### PR TITLE
Improve autolabeller performance for column graphs

### DIFF
--- a/R/axes.R
+++ b/R/axes.R
@@ -31,7 +31,7 @@ get_stacked_max_min <- function(data, xlim) {
   }
   x <- get_x_plot_locations(bardata$x, data)
   x_restriction <- x >= xlim[1] & x <= xlim[2]
-  bardata <- dplyr::select_(bardata, "-x")
+  bardata <- bardata[names(bardata) != "x"]
   bardata <- bardata[x_restriction,,drop = FALSE]
   if (ncol(bardata) > 0) {
     bardata[is.na(bardata)] <- 0

--- a/R/data.R
+++ b/R/data.R
@@ -52,22 +52,22 @@ series_names <- function(x) {
 get_bar_data <- function(data) {
   colours <- c()
   bordercol <- c()
-  bardata <- data.frame(x = data$x, stringsAsFactors = FALSE)
+  bardata <- data.frame(agg_xvalues = data$x, stringsAsFactors = FALSE)
 
   for (i in seq_along(data$series)) {
     s <- data$series[[i]]
     if (s$bar) {
       colours <- append(colours, s$attributes$col)
       bordercol <- append(bordercol, s$attributes$barcol)
-      series_data <- data.frame(x = series_x_values(data, i), y = series_values(data, i), stringsAsFactors = FALSE)
-      names(series_data) <- c("x", i)
+      series_data <- data.frame(agg_xvalues = series_x_values(data, i), y = series_values(data, i), stringsAsFactors = FALSE)
+      names(series_data) <- c("agg_xvalues", i)
       if (anyDuplicated(series_data$x)) {
         stop(paste0("Series ", s$name, " invalid. Bar graphs cannot have duplicate entries for x values."))
       }
-      bardata <- dplyr::left_join(bardata, series_data, by = "x")
+      bardata <- dplyr::left_join(bardata, series_data, by = "agg_xvalues")
     }
   }
-  bardata <- dplyr::select_(bardata, "-x")
+  bardata <- bardata[names(bardata) != "x"]
   return(list(bardata=bardata, colours=colours, bordercol=bordercol))
 }
 

--- a/R/data.R
+++ b/R/data.R
@@ -86,8 +86,8 @@ convert_to_plot_bardata <- function(bardata, data) {
         bardata <- dplyr::add_row(bardata, x = x)
       }
     }
-    bardata <- dplyr::arrange_(bardata, "x")
-    bardata <- dplyr::select_(bardata, "-x")
+    bardata <- bardata[order(bardata$x), ]
+    bardata <- bardata[names(bardata) != "x"]
   }
   bardata_n <- t(as.matrix(bardata))
   bardata_n[is.na(bardata_n)] <- 0 # singletons don't show otherwise (#82)

--- a/R/data.R
+++ b/R/data.R
@@ -49,7 +49,7 @@ series_names <- function(x) {
   sapply(x$series, function(y) y$name)
 }
 
-get_bar_data <- function(data) {
+extract_bar_data <- function(data) {
   colours <- c()
   bordercol <- c()
   bardata <- data.frame(agg_xvalues = data$x, stringsAsFactors = FALSE)
@@ -68,7 +68,11 @@ get_bar_data <- function(data) {
     }
   }
   bardata <- bardata[names(bardata) != "agg_xvalues"]
-  return(list(bardata=bardata, colours=colours, bordercol=bordercol))
+  return(append(data, list(bars = list(bardata=bardata, colours=colours, bordercol=bordercol))))
+}
+
+get_bar_data <- function(data) {
+  data$bars
 }
 
 convert_to_plot_bardata <- function(bardata, data) {

--- a/R/data.R
+++ b/R/data.R
@@ -61,7 +61,7 @@ extract_bar_data <- function(data) {
       bordercol <- append(bordercol, s$attributes$barcol)
       series_data <- data.frame(agg_xvalues = series_x_values(data, i), y = series_values(data, i), stringsAsFactors = FALSE)
       names(series_data) <- c("agg_xvalues", i)
-      if (anyDuplicated(series_data$x)) {
+      if (anyDuplicated(series_data$agg_xvalues)) {
         stop(paste0("Series ", s$name, " invalid. Bar graphs cannot have duplicate entries for x values."))
       }
       bardata <- dplyr::left_join(bardata, series_data, by = "agg_xvalues")

--- a/R/data.R
+++ b/R/data.R
@@ -67,7 +67,7 @@ get_bar_data <- function(data) {
       bardata <- dplyr::left_join(bardata, series_data, by = "agg_xvalues")
     }
   }
-  bardata <- bardata[names(bardata) != "x"]
+  bardata <- bardata[names(bardata) != "agg_xvalues"]
   return(list(bardata=bardata, colours=colours, bordercol=bordercol))
 }
 

--- a/R/data.R
+++ b/R/data.R
@@ -90,6 +90,7 @@ convert_to_plot_bardata <- function(bardata, data) {
     bardata <- bardata[names(bardata) != "x"]
   }
   bardata_n <- t(as.matrix(bardata))
+  colnames(bardata_n) <- NULL
   bardata_n[is.na(bardata_n)] <- 0 # singletons don't show otherwise (#82)
   # Split into positive and negative (R doesn't stack well across axes)
   bardata_p <- bardata_n

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -394,7 +394,7 @@ drawbars <- function(l, data, xlim, ylim, bar.stacked, log_scale) {
 
     xlim <- as.barplot.x(bardata_p, bar_x_loc, xlim, bar.stacked)
     graphics::par(mfg = l)
-    graphics::barplot(bardata_p, col = colours, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
+    graphics::barplot(bardata_p, col = colours, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale, names.arg = NULL)
     graphics::par(mfg = l)
     graphics::barplot(bardata_n, col = colours, border = bordercol, xlim = xlim, ylim = c(ylim$min, ylim$max), xlab = "", ylab = "", axes = FALSE, beside = (!bar.stacked), log = log_scale)
   }

--- a/R/main.R
+++ b/R/main.R
@@ -21,6 +21,9 @@ agg_draw_internal <- function(gg, filename) {
   # handle series attributes
   data <- handleattributes(data)
 
+  # split out bardata, as that has to be plotted separately
+  data <- lapply(data, extract_bar_data)
+
   # Units and scales
   yunits <- handleunits(data, gg$yunits, gg$layout)
   xunits <- handlexunits(names(data), gg$xunits)


### PR DESCRIPTION
Bar graphs are significantly slower for the autolabeller than for line graphs.

This is due to unnecessary `dplyr` NSE calls and repeated calculation of bar data that can be pre-allocated.