### PR TITLE
Throw error if pass in vector for titles

### DIFF
--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -19,6 +19,9 @@ agg_title <- function(text, panel = NULL) {
   if (!is.null(panel)) {
     panel <- as.character(panel)
   }
+  if (length(text) > 1) {
+    stop("text for title should be a single character, not a vector")
+  }
   if (!is.null(panel)) check_panel(panel)
   return(list(type = "title", text = text, panel = panel))
 }
@@ -39,6 +42,9 @@ agg_title <- function(text, panel = NULL) {
 agg_subtitle <- function(text, panel = NULL) {
   if (!is.null(panel)) {
     panel <- as.character(panel)
+  }
+  if (length(text) > 1) {
+    stop("text for subtitle should be a single character, not a vector")
   }
   if (!is.null(panel)) check_panel(panel)
   return(list(type = "subtitle", text = text, panel = panel))

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -20,7 +20,8 @@ agg_title <- function(text, panel = NULL) {
     panel <- as.character(panel)
   }
   if (length(text) > 1) {
-    stop("text for title should be a single character, not a vector")
+    stop("text for title should be a single character, not a vector",
+         call. = FALSE)
   }
   if (!is.null(panel)) check_panel(panel)
   return(list(type = "title", text = text, panel = panel))
@@ -44,7 +45,8 @@ agg_subtitle <- function(text, panel = NULL) {
     panel <- as.character(panel)
   }
   if (length(text) > 1) {
-    stop("text for subtitle should be a single character, not a vector")
+    stop("text for subtitle should be a single character, not a vector",
+         call. = FALSE)
   }
   if (!is.null(panel)) check_panel(panel)
   return(list(type = "subtitle", text = text, panel = panel))

--- a/tests/testthat/test-notes.R
+++ b/tests/testthat/test-notes.R
@@ -20,6 +20,11 @@ test_that("Title", {
   expect_true(check_graph(p, "notes-long-title-manual-breaks", 0.945)) # Needs lower distortion because is text heavy
 })
 
+test_that("Errors for bad titles", {
+  expect_error(arphitgg() + agg_title(c("foo","bar")),
+               "text for title should be a single character, not a vector")
+})
+
 
 ## Subtitle ===================
 
@@ -49,6 +54,12 @@ test_that("Subtitle and title", {
     agg_subtitle("Now a subtitle, which is fun", panel = "1")
   expect_true(check_graph(p, "notes-title-and-subtitle", 0.92)) # Needs lower distortion because is text heavy
 })
+test_that("Errors for bad subtitles", {
+  expect_error(arphitgg() + agg_subtitle(c("foo","bar")),
+               "text for subtitle should be a single character, not a vector")
+})
+
+
 
 ## Footnotes ===================
 


### PR DESCRIPTION
Otherwise get a confusing error message much later than makes sense.

Closes #320 