### PR TITLE
Special case autolabeller for identical bar series

### DIFF
--- a/R/autolabel-distance.R
+++ b/R/autolabel-distance.R
@@ -51,6 +51,7 @@ point_bar_distance <- function(x, y, series.x, series.y, data, bars.stacked, inc
   } else {
     bardata <- get_bar_data(data)$bardata
     row_n <- which(sapply(seq_along(bardata), function(i) identical(bardata[[i]][!is.na(bardata[[i]])], series.y[!is.na(series.y)])))
+    if (length(row_n) > 1) row_n <- row_n[1] # only occurs if have two identical bar series. Rare special case.
     # I use !is.na because bardata has been widened to all x observations, while series.y hasn't
     if (row_n == 1) {
       return(point_bar_distance_(x, y, series.x, rep(0, length(series.y)), series.y, inches_conversion))

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -276,4 +276,8 @@ test_that("Miscellaneous tests", {
     agg_line(colour = "black") + agg_col(colour = "black") + agg_point(colour = "black") +
     agg_autolabel()
   expect_true(check_graph(p, "autolabel-misc-same-colour-layers-278"))
+
+  # Warnings with bar graphs (#319)
+  p <- arphitgg(data.frame(x=1:10,y=1:10),agg_aes(x,y))+agg_col()+agg_col()+agg_autolabel()
+  expect_warning(print(p), NA)
 })

--- a/tests/testthat/test-autolabel.R
+++ b/tests/testthat/test-autolabel.R
@@ -277,7 +277,7 @@ test_that("Miscellaneous tests", {
     agg_autolabel()
   expect_true(check_graph(p, "autolabel-misc-same-colour-layers-278"))
 
-  # Warnings with bar graphs (#319)
+  # Warnings with identical duplicate series in bar graphs (#319)
   p <- arphitgg(data.frame(x=1:10,y=1:10),agg_aes(x,y))+agg_col()+agg_col()+agg_autolabel()
   expect_warning(print(p), NA)
 })


### PR DESCRIPTION
Otherwise the autolabeller identifies two series that it could be, causing problems.

Closes #319.