### PR TITLE
Add call. = FALSE to error messages

### DIFF
--- a/R/annotations.R
+++ b/R/annotations.R
@@ -1,8 +1,8 @@
 sanitycheck.specificline <- function(line) {
-  if (is.null(line$x1)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x1.")
-  if (is.null(line$x2)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x2.")
-  if (is.null(line$y1)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing y1.")
-  if (is.null(line$y2)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing y2.")
+  if (is.null(line$x1)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x1.", call. = FALSE)
+  if (is.null(line$x2)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing x2.", call. = FALSE)
+  if (is.null(line$y1)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing y1.", call. = FALSE)
+  if (is.null(line$y2)) stop("Line was specified without x or y (i.e. not a horizontal or vertical line), but is missing y2.", call. = FALSE)
   return(line)
 }
 

--- a/R/data.R
+++ b/R/data.R
@@ -1,9 +1,9 @@
 check_series_has_obs_is_finite <- function(y, name) {
   if (length(y) == 0) {
-    stop(paste0("Series ", name, " has no observations."))
+    stop(paste0("Series ", name, " has no observations."), call. = FALSE)
   }
   if (any(is.infinite(y))) {
-    stop(paste0("Series ", name, " contains non-finite values."))
+    stop(paste0("Series ", name, " contains non-finite values."), call. = FALSE)
   }
 }
 
@@ -62,7 +62,8 @@ extract_bar_data <- function(data) {
       series_data <- data.frame(agg_xvalues = series_x_values(data, i), y = series_values(data, i), stringsAsFactors = FALSE)
       names(series_data) <- c("agg_xvalues", i)
       if (anyDuplicated(series_data$agg_xvalues)) {
-        stop(paste0("Series ", s$name, " invalid. Bar graphs cannot have duplicate entries for x values."))
+        stop(paste0("Series ", s$name, " invalid. Bar graphs cannot have duplicate entries for x values."),
+             call. = FALSE)
       }
       bardata <- dplyr::left_join(bardata, series_data, by = "agg_xvalues")
     }

--- a/R/draw-figure.R
+++ b/R/draw-figure.R
@@ -19,7 +19,7 @@ finddevice <- function(filename) {
     if (filetype == "png" || filetype == "pdf" || filetype == "emf" || filetype == "svg" || filetype == "emf+" || filetype == "xlsx") {
       return(filetype)
     } else {
-      stop(paste("Unsupported file type ", filetype, ".", sep = ""))
+      stop(paste("Unsupported file type ", filetype, ".", sep = ""), call. = FALSE)
     }
   }
 }
@@ -163,7 +163,10 @@ handlelayout <- function(layout) {
   } else if (layout == "4b2") {
     graphics::par(mfrow=c(4,2))
   } else {
-    stop(paste("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2.", sep = ""))
+    stop(paste("Unknown layout option ", layout,
+               ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2.",
+               sep = ""),
+         call. = FALSE)
   }
   graphics::par(cex=1)
 }

--- a/R/draw-panel.R
+++ b/R/draw-panel.R
@@ -59,7 +59,9 @@ getlocation <- function(p, layout) {
                "7" = c(4,1),
                "8" = c(4,2))
   } else {
-    stop(paste0("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2."))
+    stop(paste0("Unknown layout option ", layout,
+                ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2."),
+         call. = FALSE)
   }
 }
 
@@ -96,7 +98,7 @@ getsides <- function(p, layout) {
     } else if (p == "2") {
       side <- 4
     } else {
-      stop(paste("Layout ", layout, " does not have panel ", p, sep = ""))
+      stop(paste0("Layout ", layout, " does not have panel ", p), call. = FALSE)
     }
   } else if (layout == "2h" || layout == "2b2") {
     if (p == "1" || p == "3") {
@@ -104,7 +106,7 @@ getsides <- function(p, layout) {
     } else if (p == "2" || p == "4") {
       side <- 4
     } else {
-      stop(paste("Layout ", layout, " does not have panel ", p, sep = ""))
+      stop(paste0("Layout ", layout, " does not have panel ", p), call. = FALSE)
     }
   } else if (layout == "3v") {
     if (p == "1") {
@@ -114,7 +116,7 @@ getsides <- function(p, layout) {
     } else if (p == "3") {
       side <- 4
     } else {
-      stop(paste0("Layout ", layout, " does not have panel ", p))
+      stop(paste0("Layout ", layout, " does not have panel ", p), call. = FALSE)
     }
   } else if (layout == "3h" || layout == "3b2") {
     if (p == "1" || p == "3" || p == "5") {
@@ -122,7 +124,7 @@ getsides <- function(p, layout) {
     } else if (p == "2" || p == "4" || p == "6") {
       side <- 4
     } else {
-      stop(paste0("Layout ", layout, " does not have panel ", p))
+      stop(paste0("Layout ", layout, " does not have panel ", p), call. = FALSE)
     }
   } else if (layout == "4h" || layout == "4b2") {
     if (p == "1" || p == "3" || p == "5" || p == "7") {
@@ -130,10 +132,12 @@ getsides <- function(p, layout) {
     } else if (p == "2" || p == "4" || p == "6" || p == "8") {
       side <- 4
     } else {
-      stop(paste0("Layout ", layout, " does not have panel ", p))
+      stop(paste0("Layout ", layout, " does not have panel ", p), call. = FALSE)
     }
   } else  {
-    stop(paste("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3h, 3v, 3b2, 4h, 4b2.", sep = ""))
+    stop(paste0("Unknown layout option ", layout,
+               ". Options are 1, 2h, 2v, 2b2, 3h, 3v, 3b2, 4h, 4b2."),
+         call. = FALSE)
   }
   return(side)
 }
@@ -178,7 +182,10 @@ needxlabels <- function(p, layout) {
   } else if (layout == "4b2") {
     return(p == "7" || p == "8")
   } else {
-    stop(paste("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3h, 3v, 3b2, 4h, 4b2.", sep = ""))
+    stop(paste("Unknown layout option ", layout,
+               ". Options are 1, 2h, 2v, 2b2, 3h, 3v, 3b2, 4h, 4b2.",
+               sep = ""),
+         call. = FALSE)
   }
 }
 
@@ -192,7 +199,10 @@ dropbottomlabel <- function(p, layout) {
   } else if (layout == "4h" || layout == "4b2") {
     return(p == "1" || p == "2" || p == "3" || p == "4" || p == "5" || p == "6")
   } else {
-    stop(paste("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2.", sep = ""))
+    stop(paste("Unknown layout option ", layout,
+               ". Options are 1, 2h, 2v, 2b2.",
+               sep = ""),
+         call. = FALSE)
   }
 }
 
@@ -208,7 +218,9 @@ needgrid <- function(p, layout) {
   } else if (layout == "2v" || layout == "2b2" || layout == "3v" || layout == "3b2" || layout == "4b2") {
     return(TRUE)
   } else {
-    stop(paste0("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2."))
+    stop(paste0("Unknown layout option ", layout,
+                ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4h, 4b2."),
+         call. = FALSE)
   }
 }
 

--- a/R/gg-add-layers.R
+++ b/R/gg-add-layers.R
@@ -18,7 +18,7 @@ autolayout <- function(n) {
                    "6" = "3b2",
                    "7" = "4b2",
                    "8" = "4b2",
-                   stop(paste0("Cannot layout ", n, " facets.")))
+                   stop(paste0("Cannot layout ", n, " facets.")), call. = FALSE)
 
   panels <- switch(as.character(n),
                    "1" = c("1"),
@@ -56,10 +56,12 @@ facetlayout <- function(data, facet, layout) {
 
 sanity_check_aesthetic <- function(aes) {
   if (is_null_quo(aes$x)) {
-    stop("Cannot add layer. You have not specified an x aesthetic (and there was not one to inherit).")
+    stop("Cannot add layer. You have not specified an x aesthetic (and there was not one to inherit).",
+         call. = FALSE)
   }
   if (is_null_quo(aes$y)) {
-    stop("Cannot add layer. You have not specified a y aesthetic for at least one of your layers (and there was not one to inherit).")
+    stop("Cannot add layer. You have not specified a y aesthetic for at least one of your layers (and there was not one to inherit).",
+         call. = FALSE)
   }
 }
 
@@ -77,9 +79,18 @@ is_null_quo <- function(x) {
 }
 
 check_aes_in_data <- function(data, aes, panel) {
-  if (!try_tidy(aes$x, data)) stop(paste0(rlang::quo_name(aes$x)," is not in your data for panel ", panel))
-  if (!try_tidy(aes$y, data)) stop(paste0(rlang::quo_name(aes$y)," is not in your data for panel ", panel))
-  if (!is_null_quo(aes$group) && !try_tidy(aes$group, data)) stop(paste0(rlang::quo_name(aes$group)," is not in your data for panel ", panel))
+  if (!try_tidy(aes$x, data)) {
+    stop(paste0(rlang::quo_name(aes$x)," is not in your data for panel ", panel),
+         call. = FALSE)
+  }
+  if (!try_tidy(aes$y, data)) {
+    stop(paste0(rlang::quo_name(aes$y)," is not in your data for panel ", panel),
+         call. = FALSE)
+  }
+  if (!is_null_quo(aes$group) && !try_tidy(aes$group, data)) {
+    stop(paste0(rlang::quo_name(aes$group)," is not in your data for panel ", panel),
+         call. = FALSE)
+  }
 }
 
 convert_data <- function(data, aes) {
@@ -110,7 +121,9 @@ widen_x <- function(gg, data, aes, panel) {
   if (!is.null(old_x) && class(new_x) != class(old_x) &&
       !((class(new_x)=="integer" && class(old_x)=="numeric") ||
         (class(old_x)=="integer" && class(new_x)=="numeric"))) {
-    stop(paste0("Do not know how to join together x values ", class(new_x), " and ", class(old_x), " (panel ", panel, ")"))
+    stop(paste0("Do not know how to join together x values ",
+                class(new_x), " and ", class(old_x), " (panel ", panel, ")"),
+         call. = FALSE)
   }
   gg$data[[panel]]$x <- unique(c(new_x,old_x))
   return(gg)
@@ -155,14 +168,17 @@ reorder_series <- function(gg, data, aes, panel) {
       class(new_order_mapping$order) != class(gg$data[[panel]]$order_mapping$order) &&
       !((class(new_order_mapping$order)=="integer" && class(gg$data[[panel]]$order_mapping$order)=="numeric") ||
         (class(gg$data[[panel]]$order_mapping$order)=="integer" && class(new_order_mapping$order)=="numeric"))) {
-    stop(paste0("Do not know how to join together ordering variables with classes ", class(new_order_mapping$order), " and ", class(gg$data[[panel]]$order_mapping$order), " (panel ", panel, "). Perhaps you added layers to the same panel with different ordering variables (or didn't specify an ordering variable for one of the layers)?"))
+    stop(paste0("Do not know how to join together ordering variables with classes ",
+                class(new_order_mapping$order), " and ", class(gg$data[[panel]]$order_mapping$order),
+                " (panel ", panel, "). Perhaps you added layers to the same panel with different ordering variables (or didn't specify an ordering variable for one of the layers)?"),
+         call. = FALSE)
   }
   gg$data[[panel]]$order_mapping <- unique(rbind(new_order_mapping, gg$data[[panel]]$order_mapping))
 
   # Check for ambiguity
   if (anyDuplicated(gg$data[[panel]]$order_mapping$x) ||
       nrow(gg$data[[panel]]$order_mapping) != length(gg$data[[panel]]$x)) {
-    stop("Ordering is ambiguous - some x values associate with multiple values of the ordering variable, or there are no observations of the ordering variable for some x values.")
+    stop("Ordering is ambiguous - some x values associate with multiple values of the ordering variable, or there are no observations of the ordering variable for some x values.", call. = FALSE)
   }
 
   # sort the order mapping
@@ -241,7 +257,7 @@ inherit_data <- function(gg, data) {
   if (is.null(data)) {
     data <- gg$data[["parent"]]
     if (is.null(data)) {
-      stop("You have not supplied data for series")
+      stop("You have not supplied data for series", call. = FALSE)
     }
   }
   return(data)
@@ -252,7 +268,8 @@ addlayer <- function(gg, new, panel, bar) {
   data <- inherit_data(gg, new$data)
   # Error if data is weird
   if (!is.acceptable.data(data)) {
-    stop(paste0("Data is of unsupported type (you passed in ", class(data),")"))
+    stop(paste0("Data is of unsupported type (you passed in ", class(data),")"),
+         call. = FALSE)
   }
 
   if (is_null_quo(aes$facet)) {

--- a/R/gg-constructors.R
+++ b/R/gg-constructors.R
@@ -1,5 +1,8 @@
 check_panel <- function(panel) {
-  if (!all(panel %in% as.character(1:8))) stop(paste0("Panel identifier '", panel, "' is invalid. Panels must be between 1 and 8."))
+  if (!all(panel %in% as.character(1:8))) {
+    stop(paste0("Panel identifier '", panel, "' is invalid. Panels must be between 1 and 8."),
+         call. = FALSE)
+  }
 }
 
 #' Add a title or panel title
@@ -352,7 +355,7 @@ agg_shading <- function(from, to, panel = NULL, colour = RBA["Grey2"], color) {
 #' @export
 agg_ylim <- function(min, max, nsteps, panel = NULL) {
   if (nsteps < 2) {
-    stop("The y-limit you supplied has fewer than 2 points.")
+    stop("The y-limit you supplied has fewer than 2 points.", call. = FALSE)
   }
   if (!is.null(panel)) check_panel(panel)
   return(list(type = "ylim", min = min, max = max, nsteps = nsteps, panel = panel))
@@ -389,7 +392,7 @@ agg_xlim <- function(min, max, panel = NULL) {
 agg_xaxisfreq <- function(freq, panel = NULL) {
   if (!is.null(panel)) check_panel(panel)
   if (!freq %in% c("decade","year","quarter","month")) {
-    stop(paste0(freq, " is not a valid frequency"))
+    stop(paste0(freq, " is not a valid frequency"), call. = FALSE)
   }
   return(list(type = "xfreq", freq = freq, panel = panel))
 }
@@ -418,12 +421,12 @@ agg_xaxisfreq <- function(freq, panel = NULL) {
 #' @export
 agg_legend <- function(ncol = NULL, x = NULL, y = NULL) {
   if (!is.null(x)) {
-    if (is.numeric(x) && (is.null(y))) stop("You must specify a y coordinate if you specify an x coordinate for on panel legends")
+    if (is.numeric(x) && (is.null(y))) stop("You must specify a y coordinate if you specify an x coordinate for on panel legends", call. = FALSE)
     if (is.character(x)) {
       y <- NULL
       if (!x %in% c("bottomright", "bottom", "bottomleft", "left", "topleft",
                     "top", "topright", "right", "center")) {
-        stop("Valid options for automatic placement of on panel legend are bottomright, bottom, bottomleft, left, topleft, top, topright, right and center")
+        stop("Valid options for automatic placement of on panel legend are bottomright, bottom, bottomleft, left, topleft, top, topright, right and center", call. = FALSE)
       }
     }
   }

--- a/R/gg-operators.R
+++ b/R/gg-operators.R
@@ -61,6 +61,6 @@ print.arphit.gg <- function(x, ...) {
          "legend" = addlegend(gg, element),
          "autolabel" = enableautolabel(gg, element$quiet, element$arrow_lines, element$arrow_bars),
          "xfreq" = addxfreq(gg, element$freq, element$panel),
-         stop("Unknown element type for arphit.gg"))
+         stop("Unknown element type for arphit.gg", call. = FALSE))
   return(gg)
 }

--- a/R/main.R
+++ b/R/main.R
@@ -3,7 +3,8 @@ agg_draw_internal <- function(gg, filename) {
 
   if (any(!names(gg$data) %in% permitted_panels(gg$layout))) {
     inval_panel <-  names(gg$data)[!names(gg$data) %in% permitted_panels(gg$layout)]
-    stop(paste0("Your chosen layout (", gg$layout,") does not have a panel ", inval_panel, "."))
+    stop(paste0("Your chosen layout (", gg$layout,") does not have a panel ", inval_panel, "."),
+         call. = FALSE)
   }
 
   data <- convert_ts_to_decimal_date(gg$data)
@@ -31,14 +32,14 @@ agg_draw_internal <- function(gg, filename) {
   xaxislabels <- handleaxislabels(gg$xaxislabels, names(data))
 
   if (length(gg$xlim)==0 && (gg$log_scale == "x" || gg$log_scale == "xy")) {
-    stop("You must manually set x axis limits for log scale plots.")
+    stop("You must manually set x axis limits for log scale plots.", call. = FALSE)
   }
   xlim <- xlimconform(gg$xlim, data, gg$layout)
   xlabels <- handlexlabels(data, xlim, gg$xfreq, gg$layout, gg$showallxlabels)
   xlim <- collapse_in_padding(xlim)
 
   if (length(gg$ylim)==0 && (gg$log_scale == "y" || gg$log_scale == "xy")) {
-    stop("You must manually set y axis limits for log scale plots.")
+    stop("You must manually set y axis limits for log scale plots.", call. = FALSE)
   }
   ylim <- ylimconform(gg$ylim, data, gg$layout, gg$stacked, xlim)
   yticks <- handleticks(data, ylim)

--- a/R/panels.R
+++ b/R/panels.R
@@ -11,7 +11,9 @@ maxpanels <- function(layout) {
   } else if (layout == "4h" || layout == "4b2") {
     maxnp <- 8
   } else {
-    stop(paste0("Unknown layout option ", layout, ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4b2."))
+    stop(paste0("Unknown layout option ", layout,
+                ". Options are 1, 2h, 2v, 2b2, 3v, 3h, 3b2, 4b2."),
+         call. = FALSE)
   }
   return(maxnp)
 }

--- a/R/qplot.R
+++ b/R/qplot.R
@@ -1,20 +1,23 @@
 sanity_check_ylim <- function(ylim) {
-  if (!is.list(ylim)) stop("ylim should be a list")
+  if (!is.list(ylim)) stop("ylim should be a list", call. = FALSE)
   if (is.null(ylim$nsteps) || ylim$nsteps < 2) {
-    stop("The y-limit you supplied has fewer than 2 points (or you forgot to supply nsteps).")
+    stop("The y-limit you supplied has fewer than 2 points (or you forgot to supply nsteps).",
+         call. = FALSE)
   }
   if (is.null(ylim$max)) {
-    stop("You did not supply a max ylimit.")
+    stop("You did not supply a max ylimit.", call. = FALSE)
   }
   if (is.null(ylim$min)) {
-    stop("You did not supply a min ylimit.")
+    stop("You did not supply a min ylimit.", call. = FALSE)
   }
 }
 
 check_attribute_series_names <- function(attr, series_names) {
   if (any(!names(attr) %in% series_names)) {
     name <- names(attr)[!names(attr) %in% series_names]
-    stop(paste0("You have tried to set attributes for ", name, " but it is not a series in your data."))
+    stop(paste0("You have tried to set attributes for ", name,
+                " but it is not a series in your data."),
+         call. = FALSE)
   }
 }
 
@@ -84,7 +87,10 @@ qplot_get_attribute <- function(att, y) {
 #' @export
 agg_qplot <- function(data, series = NULL, x = NULL, bars = FALSE, filename = NULL, title = NULL, subtitle = NULL, footnotes = c(), sources = c(), yunits = NULL, col = list(), pch = list(), lty = list(), lwd = list(), xlim = NULL, ylim = NULL, legend = FALSE, legend.ncol = NA, bar.stacked = TRUE) {
 
-  if (!is.acceptable.data(data)) stop(paste0("Data is of unsupported type (you passed in ", class(data),")"))
+  if (!is.acceptable.data(data)) {
+    stop(paste0("Data is of unsupported type (you passed in ", class(data),")"),
+         call. = FALSE)
+  }
 
   # Create the basics
   p <- arphitgg(data) + agg_title(title) + agg_subtitle(subtitle) +

--- a/R/shading.R
+++ b/R/shading.R
@@ -1,9 +1,11 @@
 shadingsanity <- function(to, from, data, p) {
   if (!(to %in% series_names(data[[p]]))) {
-    stop(paste("Series ", to, " from your shading options is not a recognised series in panel ", p, ".", sep = ""))
+    stop(paste0("Series ", to, " from your shading options is not a recognised series in panel ", p),
+         call. = FALSE)
   }
   if (!(from %in% series_names(data[[p]]))) {
-    stop(paste("Series ", from, " from your shading options is not a recognised series in panel ", p, ".", sep = ""))
+    stop(paste0("Series ", from, " from your shading options is not a recognised series in panel ", p),
+         call. = FALSE)
   }
 }
 
@@ -14,12 +16,15 @@ findpanel <- function(data, name) {
   	  if (is.null(match)) {
           match <- p
   	  } else {
-  	    stop(paste("Cannot construct shading from series ", name, " because its name is in more than one panel. Supply a panel identifier for the shading.", sep = ""))
+  	    stop(paste0("Cannot construct shading from series ", name,
+  	               " because its name is in more than one panel. Supply a panel identifier for the shading."),
+  	         call. = FALSE)
   	  }
     }
   }
   if (is.null(match)) {
-    stop(paste("Cannot shade with series ", name, " because it does not exist in any panel.", sep = ""))
+    stop(paste0("Cannot shade with series ", name, " because it does not exist in any panel."),
+         call. = FALSE)
   }
   return(match)
 }
@@ -34,7 +39,9 @@ handleshading <- function(shading, data) {
   for (s in shading) {
   	if (is.null(s$panel)) {
   	  s$panel <- findpanel(data, s$to)
-  	  message(paste("No panel identifier supplied for shading. Assuming for panel ", s$panel, " where a matching series can be found.", sep = ""))
+  	  message(paste0("No panel identifier supplied for shading. Assuming for panel ",
+  	                s$panel, " where a matching series can be found."),
+  	          call. = FALSE)
   	}
     shadingsanity(s$to, s$from, data, s$panel)
 

--- a/R/xvars.R
+++ b/R/xvars.R
@@ -29,7 +29,7 @@ make_decimal_date <- function(date, frequency) {
   } else if (frequency == 1/365) {
     return(lubridate::year(date) + (lubridate::yday(date) - 0.5)/days_in_year(date))
   }
-  stop("Unknown frequency")
+  stop("Unknown frequency", call. = FALSE)
 }
 
 

--- a/tests/testthat/test-shading.R
+++ b/tests/testthat/test-shading.R
@@ -36,13 +36,13 @@ test_that("Error handling", {
     agg_line(agg_aes(x=x,y=y)) +
     agg_line(agg_aes(x=x,y=y2)) +
     agg_shading(y3, y)
-  expect_error(print(p), "Series y3 from your shading options is not a recognised series in panel 1.")
+  expect_error(print(p), "Series y3 from your shading options is not a recognised series in panel 1")
 
   p <- arphitgg(data)  +
     agg_line(agg_aes(x=x,y=y)) +
     agg_line(agg_aes(x=x,y=y2)) +
     agg_shading(y, y3, panel = "1")
-  expect_error(print(p), "Series y3 from your shading options is not a recognised series in panel 1.")
+  expect_error(print(p), "Series y3 from your shading options is not a recognised series in panel 1")
 
   p <- arphitgg(data)  +
     agg_line(agg_aes(x=x,y=y)) +


### PR DESCRIPTION
Makes the user-facing error message cleaner as it doesn't include the throw-site function name (which is usually somewhere deep in the internals).

Closes #321 