### PR TITLE
Use get_x_plot_location for comparing against xlimits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
   knitr,
   rmarkdown,
   covr,
-  pkgdown
+  pkgdown,
+  readxl
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr

--- a/R/write-xlsx.R
+++ b/R/write-xlsx.R
@@ -11,12 +11,13 @@ create_data_panel <- function(panel, xlim) {
   return(df)
 }
 
-restrict_xlim_xlsx <- function(panel, xlim) {
+restrict_xlim_xlsx <- function(panel, data, xlim) {
   if (is.null(xlim)) xlim <- c(-Inf, Inf)
   if (is.na(xlim[1])) xlim[1] <- -Inf
   if (is.na(xlim[2])) xlim[2] <- Inf
 
-  indices <- panel[[1]]
+  indices <- get_x_plot_locations(panel[[1]], data)
+
   if (lubridate::is.Date(indices) || lubridate::is.POSIXt(indices)) {
     freq <- frequencyof(indices)
     indices <- make_decimal_date(indices, freq)
@@ -41,12 +42,13 @@ write_to_excel <- function(gg, filename) {
     )
 
   panels <- lapply(gg$data, create_data_panel)
+  data <- convert_ts_to_decimal_date(gg$data)
 
   # Handle applying x lim to all axes
   if (!is.list(gg$xlim)) gg$xlim <- lapply(panels, function(x) gg$xlim)
 
   for (p in names(panels)) {
-    panels[[p]] <- restrict_xlim_xlsx(panels[[p]], gg$xlim[[p]])
+    panels[[p]] <- restrict_xlim_xlsx(panels[[p]], data[[p]], gg$xlim[[p]])
   }
 
   writexl::write_xlsx(append(list(Meta = metadata), panels),

--- a/tests/testthat/test-write-xlsx.R
+++ b/tests/testthat/test-write-xlsx.R
@@ -40,6 +40,13 @@ test_that("Smoke tests", {
   p <- arphitgg(data, agg_aes(x=agg_time,y=x1)) + agg_line() + agg_xlim(NA, 2006)
   agg_draw(p, "test-4.xlsx")
   expect_true(file.exists("test-4.xlsx"))
+
+  # Correct number of rows #348
+  p <- arphitgg(data.frame(x=letters[1:10],y=rnorm(10),stringsAsFactors = F),
+                agg_aes(x,y)) + agg_col()
+  agg_draw(p, "baz.xlsx")
+  baz <- readxl::read_xlsx("baz.xlsx", sheet = "1")
+  expect_equal(nrow(baz), 10)
 })
 
 test_that("Characters coerced to factors (#280)", {


### PR DESCRIPTION
write-xlsx was comparing the x limits against the x _values_. For categorical graphs, this makes no sense and so was generating nonsense.

Closes #348 