### PR TITLE
Experimental first steps towards windows build on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  win: circleci/windows@1.0.0
+
 jobs:
   linux-build:
     docker:


### PR DESCRIPTION
Circle CI supports VM-based windows builds. Let's try to get that going.